### PR TITLE
Fix generate function for Vercel

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -1,8 +1,8 @@
-import OpenAI from 'openai';
+const OpenAI = require('openai');
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     res.setHeader('Content-Type', 'application/json');

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "openai": "^5.10.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## Summary
- ensure OpenAI serverless function uses CommonJS module syntax
- list `openai` as a project dependency

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878924042748326a390dea1840ac9e3