### PR TITLE
Remove OpenAI SDK and call API via fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "openai": "^5.10.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## Summary
- replace `openai.chat.completions.create` with direct `fetch` request
- parse the OpenAI response and return `name`, `tagline`, and `hero`
- remove `openai` dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68789e9e2f3483268be487a9f580971d