### PR TITLE
Add contact form loading and hide BrainROTAaS form

### DIFF
--- a/src/pages/BrainRotaas.jsx
+++ b/src/pages/BrainRotaas.jsx
@@ -176,23 +176,27 @@ export default function BrainRotaas() {
     <div className={`min-h-screen ${style.bg} ${style.text}`}>
       <div className="max-w-6xl mx-auto p-8 space-y-16">
         <header className="text-center space-y-8">
-          <form onSubmit={handleSubmit} className="space-y-4 max-w-xl mx-auto">
-            <input
-              type="text"
-              value={idea}
-              onChange={(e) => setIdea(e.target.value)}
-              placeholder="Describe your startup idea..."
-              className="w-full p-4 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 placeholder-gray-500 bg-white"
-            />
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-blue-600 text-white py-3 rounded-md font-semibold hover:bg-blue-700 transition disabled:opacity-50"
-            >
-              {loading ? 'Generating...' : 'Generate Pitch'}
-            </button>
-          </form>
-          <p className="max-w-xl mx-auto text-lg">Enter anything from your wildest idea to a half-baked concept and we'll whip up a convincing pitch. Hit the button above and see what happens!</p>
+          {!pitch && (
+            <>
+              <form onSubmit={handleSubmit} className="space-y-4 max-w-xl mx-auto">
+                <input
+                  type="text"
+                  value={idea}
+                  onChange={(e) => setIdea(e.target.value)}
+                  placeholder="Describe your startup idea..."
+                  className="w-full p-4 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 placeholder-gray-500 bg-white"
+                />
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full bg-blue-600 text-white py-3 rounded-md font-semibold hover:bg-blue-700 transition disabled:opacity-50"
+                >
+                  {loading ? 'Generating...' : 'Generate Pitch'}
+                </button>
+              </form>
+              <p className="max-w-xl mx-auto text-lg">Enter anything from your wildest idea to a half-baked concept and we'll whip up a convincing pitch. Hit the button above and see what happens!</p>
+            </>
+          )}
           {pitch && (
             <div className="space-y-4 mt-8">
               <h1 className="text-4xl md:text-6xl font-extrabold">{pitch.name}</h1>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,10 +3,12 @@ import { useState } from 'react';
 export default function Home() {
   const [message, setMessage] = useState('');
   const [toast, setToast] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!message.trim()) return;
+    if (!message.trim() || loading) return;
+    setLoading(true);
     try {
       const res = await fetch('/api/snarky', {
         method: 'POST',
@@ -19,6 +21,8 @@ export default function Home() {
       setTimeout(() => setToast(''), 5000);
     } catch (err) {
       console.error(err);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -32,8 +36,12 @@ export default function Home() {
             className="w-full p-3 rounded-md text-gray-900" rows="4" placeholder="Send me a message..."
             value={message} onChange={(e) => setMessage(e.target.value)}
           />
-          <button className="w-full py-3 bg-purple-600 hover:bg-purple-500 rounded-md font-semibold" type="submit">
-            Contact Me
+          <button
+            className="w-full py-3 bg-purple-600 hover:bg-purple-500 rounded-md font-semibold disabled:opacity-50"
+            type="submit"
+            disabled={loading}
+          >
+            {loading ? 'Sending...' : 'Contact Me'}
           </button>
         </form>
         {toast && (


### PR DESCRIPTION
## Summary
- show a spinner while sending contact messages
- hide the pitch input and instructions when a pitch is displayed

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687923678e148326a7531a1591a5c8f6