### PR TITLE
Add emojis and update CTA

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -28,6 +28,8 @@ function randomFeature() {
   };
 }
 
+const testimonialIcons = ['🎉', '🙌', '👍', '🤩', '😊'];
+
 function randomTestimonial() {
   const names = ['Alice B.', 'Bob C.', 'Charlie D.', 'Dana E.', 'Eli F.'];
   const quotes = [
@@ -37,7 +39,7 @@ function randomTestimonial() {
     'The best decision we ever made.',
     'A game changer in every way.',
   ];
-  return { name: getRandom(names), quote: getRandom(quotes) };
+  return { name: getRandom(names), quote: getRandom(quotes), icon: getRandom(testimonialIcons) };
 }
 
 function fallbackPitch(idea) {
@@ -112,7 +114,7 @@ module.exports = async function handler(req, res) {
         messages: [
           {
             role: 'user',
-            content: `Create a startup pitch for the idea "${idea}". Make the description darkly dystopian and ironically sinister. For example, a cat rescue service might boast about locking cats in a cage. Return ONLY a valid JSON object with the following fields: name (string), tagline (string), hero (string), features (array of 3 objects with title, description, and icon), testimonials (array of 2 objects with name and quote). Do not include any extra commentary, explanation, or formatting. Just the raw JSON.`,
+            content: `Create a startup pitch for the idea "${idea}". Make the description darkly dystopian and ironically sinister. For example, a cat rescue service might boast about locking cats in a cage. Return ONLY a valid JSON object with the following fields: name (string), tagline (string), hero (string), features (array of 3 objects with title, description, and icon), testimonials (array of 2 objects with name, quote, and icon). Do not include any extra commentary, explanation, or formatting. Just the raw JSON.`,
           },
         ],
         max_tokens: 400,

--- a/src/pages/BrainRotaas.jsx
+++ b/src/pages/BrainRotaas.jsx
@@ -4,9 +4,8 @@ function getRandom(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
-const icons = [
-    '⚡️', '🚀', '✨', '📈', '🧠', '☁️', '🔒', '🔧', '🎯', '🤖', '💡', '📦', '📲', '📣', '🛠️',
-  ];
+const icons=["⚡️","🚀","✨","📈","🧠","☁️","🔒","🔧","🎯","🤖","💡","📦","📲","📣","🛠️"];
+const testimonialIcons=["🎉","🙌","👍","🤩","😊"];
 
 // Fallback generator used when no API key is provided or a request fails
 function randomFeature() {
@@ -56,7 +55,7 @@ function randomTestimonial() {
     'The best decision we ever made.',
     'A game changer in every way.',
   ];
-  return { name: getRandom(names), quote: getRandom(quotes) };
+  return { name: getRandom(names), quote: getRandom(quotes), icon: getRandom(testimonialIcons) };
 }
 
 function fallbackPitch(idea) {
@@ -206,7 +205,7 @@ export default function BrainRotaas() {
                 disabled={ctaLoading}
                 className={`mt-4 px-6 py-3 rounded-lg shadow-lg hover:shadow-xl transition ${style.button} disabled:opacity-50`}
               >
-                {ctaLoading ? 'Resetting...' : 'Get Started'}
+                {ctaLoading ? 'Shit, never mind…' : 'Get Started'}
               </button>
             </div>
           )}
@@ -220,8 +219,9 @@ export default function BrainRotaas() {
                 {pitch.features?.map((f, i) => (
                   <div
                     key={i}
-                    className="bg-white text-gray-800 p-6 rounded-lg shadow"
+                    className="bg-white text-gray-800 p-6 rounded-lg shadow flex flex-col items-start"
                   >
+                    <div className="text-3xl mb-2">{f.icon}</div>
                     <h3 className="text-xl font-semibold mb-2">{f.title}</h3>
                     <p>{f.description}</p>
                   </div>
@@ -237,6 +237,7 @@ export default function BrainRotaas() {
                     key={i}
                     className="bg-white text-gray-800 p-6 rounded-lg shadow"
                   >
+                    <div className="text-3xl mb-2">{t.icon || '💬'}</div>
                     <p className="italic mb-2">"{t.quote}"</p>
                     <p className="font-semibold">- {t.name}</p>
                   </div>


### PR DESCRIPTION
## Summary
- spice up `BrainRotaas` with emoji icons for features and testimonials
- add icons to testimonial generator and API responses
- tweak OpenAI prompt accordingly
- show a cheeky message on CTA button when loading

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879284c74b88326a4e8d16ec8a924af