### PR TITLE
Fix icon conversion

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -74,13 +74,24 @@ function fallbackPitch(idea) {
 }
 
 function normalizeIcons(pitch) {
+  const alias = {
+    slap: 'raised_back_of_hand',
+  };
+
   const convert = (icon) => {
     if (!icon) return icon;
     const trimmed = icon.trim();
-    const emojified = emoji.emojify(trimmed);
-    if (emojified !== trimmed) return emojified;
-    if (emoji.has(trimmed)) return emoji.get(trimmed);
-    return icon;
+    const cleaned = trimmed
+      .replace(/(^:+|:+$)/g, '')
+      .replace(/[-_ ]?(icon|emoji)$/i, '');
+    const mapped = alias[cleaned.toLowerCase()];
+    const target = mapped || cleaned;
+    let emojified = emoji.emojify(`:${target}:`);
+    if (emojified !== `:${target}:`) return emojified;
+    if (emoji.has(target)) return emoji.get(target);
+    const results = emoji.search(target);
+    if (results.length > 0) return results[0].emoji;
+    return '❓';
   };
   if (Array.isArray(pitch.features)) {
     pitch.features = pitch.features.map((f) => ({
@@ -140,7 +151,7 @@ module.exports = async function handler(req, res) {
         messages: [
           {
             role: 'user',
-            content: `Create a startup pitch for the idea "${idea}". Make the description darkly dystopian and ironically sinister. For example, a cat rescue service might boast about locking cats in a cage. Return ONLY a valid JSON object with the following fields: name (string), tagline (string), hero (string), features (array of 3 objects with title, description, and icon), testimonials (array of 2 objects with name, quote, and icon). Do not include any extra commentary, explanation, or formatting. Just the raw JSON.`,
+            content: `Create a startup pitch for the idea "${idea}". Make the description darkly dystopian and ironically sinister. For example, a cat rescue service might boast about locking cats in a cage. Use emoji characters for all icon fields. Return ONLY a valid JSON object with the following fields: name (string), tagline (string), hero (string), features (array of 3 objects with title, description, and icon), testimonials (array of 2 objects with name, quote, and icon). Do not include any extra commentary, explanation, or formatting. Just the raw JSON.`,
           },
         ],
         max_tokens: 400,


### PR DESCRIPTION
## Summary
- convert unknown icon names to emoji and replace unknowns with a default
- nudge OpenAI prompt to use emoji characters for icon fields

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687932e2e85883269eefb05f513f0e75