### PR TITLE
Remove node-emoji, rely on emoji from API

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -1,5 +1,4 @@
 // Basic random generator used when no key is provided or the API fails
-const emoji = require('node-emoji');
 
 function getRandom(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -73,42 +72,6 @@ function fallbackPitch(idea) {
   return { name, tagline, hero, features, testimonials };
 }
 
-function normalizeIcons(pitch) {
-  const alias = {
-    slap: 'raised_back_of_hand',
-  };
-
-  const convert = (icon) => {
-    if (!icon) return icon;
-    const trimmed = icon.trim();
-    const cleaned = trimmed
-      .replace(/(^:+|:+$)/g, '')
-      .replace(/[-_ ]?(icon|emoji)$/i, '');
-    const mapped = alias[cleaned.toLowerCase()];
-    const target = mapped || cleaned;
-    let emojified = emoji.emojify(`:${target}:`);
-    if (emojified !== `:${target}:`) return emojified;
-    if (emoji.has(target)) return emoji.get(target);
-    const results = emoji.search(target);
-    if (results.length > 0) return results[0].emoji;
-    return '❓';
-  };
-  if (Array.isArray(pitch.features)) {
-    pitch.features = pitch.features.map((f) => ({
-      ...f,
-      icon: convert(f.icon),
-    }));
-  }
-  if (Array.isArray(pitch.testimonials)) {
-    pitch.testimonials = pitch.testimonials.map((t) => ({
-      ...t,
-      icon: convert(t.icon),
-    }));
-  }
-  return pitch;
-}
-
-
 module.exports = async function handler(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
@@ -132,7 +95,7 @@ module.exports = async function handler(req, res) {
     console.log("No open api key in env:", !process.env.OPENAI_API_KEY)
     // If no OpenAI key is present, fall back to a random generator
     if (!process.env.OPENAI_API_KEY) {
-      const generated = normalizeIcons(fallbackPitch(idea));
+      const generated = fallbackPitch(idea);
       res.statusCode = 200;
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify(generated));
@@ -201,7 +164,7 @@ module.exports = async function handler(req, res) {
       generated = fallbackPitch(idea);
     }
 
-    generated = normalizeIcons(generated);
+    // Icons are already returned as emoji characters
 
     res.statusCode = 200;
     res.setHeader('Content-Type', 'application/json');
@@ -212,7 +175,7 @@ module.exports = async function handler(req, res) {
     // If we have a failure from OpenAI, try the fallback generator
     if (req.body && req.body.idea) {
       try {
-        const generated = normalizeIcons(fallbackPitch(req.body.idea));
+        const generated = fallbackPitch(req.body.idea);
         res.statusCode = 200;
         res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify(generated));

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "fake-startup-site",
       "version": "0.0.1",
       "dependencies": {
-        "node-emoji": "^2.2.0",
         "openai": "^5.10.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -820,18 +819,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.1.0.tgz",
@@ -1051,15 +1038,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1214,12 +1192,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/emojilib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -1714,21 +1686,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-emoji": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
-      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^4.6.0",
-        "char-regex": "^1.0.2",
-        "emojilib": "^2.4.0",
-        "skin-tone": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/node-releases": {
@@ -2276,18 +2233,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/skin-tone": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
-      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
-      "license": "MIT",
-      "dependencies": {
-        "unicode-emoji-modifier-base": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2518,15 +2463,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/unicode-emoji-modifier-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
-      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "node-emoji": "^2.2.0",
     "openai": "^5.10.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- drop `node-emoji` dependency
- strip `normalizeIcons` helper and trust emoji strings from API
- keep fallback generator working with built-in emoji

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687939ac95648326933e288a43d6925f