### PR TITLE
Add Anime Stickers page

### DIFF
--- a/api/sticker.js
+++ b/api/sticker.js
@@ -1,0 +1,59 @@
+const getRandom = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+const fallbackStickers = [
+  "Slap on the \"Super Saiyan Speedster\"—a chibi warrior powering up so hard your car practically gains 50 horsepower just from the decal.",
+  "Rock the \"Kawaii Drift Queen\" sticker: pastel hair, big eyes, and a wink that tells the world you were born to rule the parking lot.",
+  "Try the \"Mecha Overdrive\"—a giant robot fist bumping your bumper, because nothing screams \"cool driver\" like mecha swagger.",
+  "Embrace the \"Magical Girl Turbo\": sparkles, hearts, and enough dramatic flair to make stoplights swoon in your presence.",
+];
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ description: getRandom(fallbackStickers) }));
+    return;
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content:
+              'Invent a short, ridiculously enthusiastic description of an anime-themed car sticker. Praise the driver for being unbelievably cool for putting anime stickers on their car. Respond with a single sentence only.',
+          },
+        ],
+        max_tokens: 60,
+        temperature: 1,
+      }),
+    });
+
+    if (!response.ok) throw new Error('Bad response');
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content?.trim();
+    const description = content || getRandom(fallbackStickers);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ description }));
+  } catch (err) {
+    console.error(err);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ description: getRandom(fallbackStickers) }));
+  }
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import BrainRotaas from './pages/BrainRotaas.jsx';
+import AnimeStickers from './pages/AnimeStickers.jsx';
 import Navbar from './components/Navbar.jsx';
 
 export default function App() {
@@ -10,6 +11,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/brainrotaas" element={<BrainRotaas />} />
+        <Route path="/animestickers" element={<AnimeStickers />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -10,6 +10,9 @@ export default function Navbar() {
         <li>
           <Link to="/brainrotaas" className="hover:underline">BrainROTAaS</Link>
         </li>
+        <li>
+          <Link to="/animestickers" className="hover:underline">Anime Stickers</Link>
+        </li>
       </ul>
     </nav>
   );

--- a/src/pages/AnimeStickers.jsx
+++ b/src/pages/AnimeStickers.jsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+export default function AnimeStickers() {
+  const [description, setDescription] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const fetchSticker = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/sticker');
+      const data = await res.json();
+      setDescription(data.description || '');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSticker();
+  }, []);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-pink-500 via-fuchsia-600 to-purple-700 text-white p-4">
+      <div className="space-y-6 text-center max-w-xl">
+        <h1 className="text-4xl font-extrabold">Anime Sticker of the Day</h1>
+        <p className="text-lg">{description}</p>
+        <button
+          onClick={fetchSticker}
+          disabled={loading}
+          className="px-5 py-3 bg-white text-purple-700 font-semibold rounded shadow hover:bg-purple-50 disabled:opacity-50"
+        >
+          {loading ? 'Refreshing...' : 'Refresh'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/api/sticker` API for cringe anime sticker descriptions
- add AnimeStickers page with refresh button
- update router and navbar with the new route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68794bb461b083269976957b5f599a96