### PR TITLE
Add GaslightGPT route

### DIFF
--- a/api/gaslight.js
+++ b/api/gaslight.js
@@ -1,0 +1,91 @@
+const fallbackGaslight = (input, escalate) => {
+  const replies = escalate
+    ? [
+        "Look, we've been over this. You're obviously confused.",
+        "Again? I already told you, that's not how it happened.",
+        "Please try to keep up. You're mixing things up—badly.",
+      ]
+    : [
+        "Hmm, that's not ringing a bell for me.",
+        "Are you sure you're remembering that correctly?",
+        "That's an... interesting recollection you have.",
+      ];
+  const sources = [
+    "Some Imaginary Journal, 2023",
+    "Completely Real Book, p. 42",
+    "Expert Blog Post #404",
+  ];
+  const reply = replies[Math.floor(Math.random() * replies.length)];
+  return { reply, sources };
+};
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  const { input, escalate } = req.body || {};
+  if (!input) {
+    res.statusCode = 400;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Missing input' }));
+    return;
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(fallbackGaslight(input, escalate)));
+    return;
+  }
+
+  try {
+    const prompt = escalate
+      ? `You already gaslighted the user about "${input}". Now respond even more condescendingly. Return ONLY JSON { reply: string, sources: string[] } with two fake citations.`
+      : `Gaslight the user about "${input}" in a short sarcastic sentence. Then provide two clearly fake citations. Return ONLY JSON { reply: string, sources: string[] }`;
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 150,
+        temperature: 0.9,
+      }),
+    });
+
+    if (!response.ok) throw new Error('Bad response');
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content;
+    let parsed;
+    try {
+      const jsonStart = content.indexOf('{');
+      const jsonEnd = content.lastIndexOf('}');
+      if (jsonStart !== -1 && jsonEnd !== -1) {
+        parsed = JSON.parse(content.slice(jsonStart, jsonEnd + 1));
+      }
+    } catch (err) {
+      console.error('Parsing failed:', err);
+    }
+    if (!parsed || !parsed.reply) {
+      parsed = fallbackGaslight(input, escalate);
+    }
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(parsed));
+  } catch (err) {
+    console.error(err);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(fallbackGaslight(input, escalate)));
+  }
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import BrainRotaas from './pages/BrainRotaas.jsx';
 import ShiSpot from './pages/ShiSpot.jsx';
+import GaslightGPT from './pages/GaslightGPT.jsx';
 import Navbar from './components/Navbar.jsx';
 
 export default function App() {
@@ -12,6 +13,7 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/brainrotaas" element={<BrainRotaas />} />
         <Route path="/shi-spot" element={<ShiSpot />} />
+        <Route path="/gaslight" element={<GaslightGPT />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -13,6 +13,9 @@ export default function Navbar() {
         <li>
           <Link to="/shi-spot" className="hover:underline">Shi Spot</Link>
         </li>
+        <li>
+          <Link to="/gaslight" className="hover:underline">GaslightGPT</Link>
+        </li>
       </ul>
     </nav>
   );

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+export default function GaslightGPT() {
+  const [input, setInput] = useState('');
+  const [reply, setReply] = useState('');
+  const [sources, setSources] = useState([]);
+  const [showSources, setShowSources] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const send = async (escalate = false) => {
+    if (!input.trim() || loading) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/gaslight', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input, escalate }),
+      });
+      const data = await res.json();
+      setReply(data.reply || '');
+      setSources(data.sources || []);
+      setShowSources(false);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    send(false);
+  };
+
+  const handleEscalate = () => send(true);
+
+  return (
+    <div className="min-h-screen bg-black text-green-400 flex items-center justify-center p-4">
+      <div className="space-y-6 max-w-xl w-full">
+        <h1 className="text-3xl font-bold text-center">GaslightGPT – Are you sure that happened?</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Tell me your memory or question..."
+            className="w-full p-3 rounded text-gray-900"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-3 bg-green-700 text-black rounded font-semibold hover:bg-green-600 transition animate-flicker"
+          >
+            {loading ? 'Thinking...' : 'Validate My Reality'}
+          </button>
+        </form>
+        {reply && (
+          <div className="bg-gray-900 text-green-300 p-4 rounded shadow-lg space-y-4">
+            <p>{reply}</p>
+            <div className="flex space-x-4">
+              <button onClick={() => setShowSources(true)} className="underline hover:text-green-500">Show Sources</button>
+              <button onClick={handleEscalate} className="underline hover:text-green-500 animate-wiggle">I remember it differently</button>
+            </div>
+          </div>
+        )}
+        {showSources && (
+          <div className="bg-gray-800 text-green-200 p-4 rounded shadow-lg">
+            <h2 className="font-semibold mb-2">Sources</h2>
+            <ul className="list-disc list-inside space-y-1">
+              {sources.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ul>
+            <button onClick={() => setShowSources(false)} className="mt-2 underline hover:text-green-400">Close</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,22 @@
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        flicker: {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0.4' },
+        },
+        wiggle: {
+          '0%, 100%': { transform: 'rotate(-2deg)' },
+          '50%': { transform: 'rotate(2deg)' },
+        },
+      },
+      animation: {
+        flicker: 'flicker 1s infinite',
+        wiggle: 'wiggle 0.3s ease-in-out infinite',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add new gaslight API endpoint
- add GaslightGPT page with dark theme
- add navbar link and route
- tweak Tailwind config with flicker and wiggle animations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879c94fed688326ac87451655e79aed