### PR TITLE
Add progressive disruption behavior to GaslightGPT

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,44 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Progressive disruption styles */
+body.disrupt-1 {
+  font-family: 'Comic Sans MS', cursive, sans-serif;
+}
+
+body.disrupt-2 {
+  letter-spacing: 2px;
+}
+
+body.disrupt-3 {
+  transform: rotate(1deg);
+}
+
+body.disrupt-4 {
+  filter: invert(1);
+  animation: glitch 0.3s infinite;
+}
+
+body[data-noise]::before {
+  content: attr(data-noise);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+@keyframes glitch {
+  0% {
+    text-shadow: 2px 2px red;
+  }
+  50% {
+    text-shadow: -2px -2px blue;
+  }
+  100% {
+    text-shadow: 2px -2px green;
+  }
+}

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function GaslightGPT() {
   const [input, setInput] = useState('');
@@ -6,6 +6,25 @@ export default function GaslightGPT() {
   const [sources, setSources] = useState([]);
   const [showSources, setShowSources] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [escalateCount, setEscalateCount] = useState(0);
+  const [showError, setShowError] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.remove('disrupt-1', 'disrupt-2', 'disrupt-3', 'disrupt-4');
+    if (escalateCount > 0 && escalateCount < 5) {
+      document.body.classList.add(`disrupt-${escalateCount}`);
+      document.body.dataset.noise = '!@#$%^&*'.repeat(escalateCount);
+    }
+    if (escalateCount >= 5) {
+      setShowError(true);
+      document.body.className = '';
+      document.body.style.background = 'white';
+      delete document.body.dataset.noise;
+    } else {
+      document.body.style.background = '';
+      if (escalateCount === 0) delete document.body.dataset.noise;
+    }
+  }, [escalateCount]);
 
   const send = async (escalate = false) => {
     if (!input.trim() || loading) return;
@@ -32,7 +51,28 @@ export default function GaslightGPT() {
     send(false);
   };
 
-  const handleEscalate = () => send(true);
+  const handleEscalate = () => {
+    setEscalateCount((c) => c + 1);
+    send(true);
+  };
+
+  const handleReset = () => {
+    setEscalateCount(0);
+    setShowError(false);
+    setInput('');
+    setReply('');
+    setSources([]);
+    setShowSources(false);
+  };
+
+  if (showError) {
+    return (
+      <div className="min-h-screen bg-white text-black flex flex-col items-center justify-center p-4">
+        <p className="mb-4 text-center">Error Code 480 - Maximum Number of Universes Exceeded</p>
+        <button onClick={handleReset} className="border px-4 py-2">{"let's start from the beginning"}</button>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-black text-green-400 flex items-center justify-center p-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,10 +3,10 @@ export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {
-      keyframes: {
+        keyframes: {
         flicker: {
           '0%, 100%': { opacity: '1' },
-          '50%': { opacity: '0.4' },
+          '50%': { opacity: '0.8' },
         },
         wiggle: {
           '0%, 100%': { transform: 'rotate(-2deg)' },
@@ -14,7 +14,7 @@ export default {
         },
       },
       animation: {
-        flicker: 'flicker 1s infinite',
+        flicker: 'flicker 2s infinite',
         wiggle: 'wiggle 0.3s ease-in-out infinite',
       },
     },


### PR DESCRIPTION
## Summary
- soften the flicker animation for readability
- implement escalating UI disruptions on "I remember it differently" presses
- show error screen on the 5th escalation with reset button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879cc1ad0288326ab75e54e3cd6e475