### PR TITLE
Implement escalate count in gaslight prompt

### DIFF
--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -28,12 +28,13 @@ export default function GaslightGPT() {
 
   const send = async (escalate = false) => {
     if (!input.trim() || loading) return;
+    const n = escalateCount + (escalate ? 1 : 0);
     setLoading(true);
     try {
       const res = await fetch('/api/gaslight', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ input, escalate }),
+        body: JSON.stringify({ input, n }),
       });
       const data = await res.json();
       setReply(data.reply || '');


### PR DESCRIPTION
## Summary
- track interaction count in UI and send as `n`
- adjust gaslight API to accept `n` and use it in the prompt

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879d5b81ecc8326ab68f9c3879fcad3