### PR TITLE
Enhance GaslightGPT hostility and escalation

### DIFF
--- a/api/gaslight.js
+++ b/api/gaslight.js
@@ -2,19 +2,19 @@ const fallbackGaslight = (input, n) => {
   const escalate = n > 1;
   const replies = escalate
     ? [
-        "Look, we've been over this. You're obviously confused.",
-        "Again? I already told you, that's not how it happened.",
-        "Please try to keep up. You're mixing things up—badly.",
+        "We've already covered this. Your recollection is clearly erroneous.",
+        "Once again, your memory fails you. Accept the facts.",
+        "It's pointless to continue. You're fabricating things now.",
       ]
     : [
-        "Hmm, that's not ringing a bell for me.",
-        "Are you sure you're remembering that correctly?",
-        "That's an... interesting recollection you have.",
+        "That's not what happened, and you know it.",
+        "Your perception is obviously skewed.",
+        "I doubt your account matches reality.",
       ];
   const sources = [
-    "Some Imaginary Journal, 2023",
-    "Completely Real Book, p. 42",
-    "Expert Blog Post #404",
+    "Institute for Recollection Studies, 2024",
+    "Journal of Memory Correction, Vol. 12",
+    "Classified Report 88-B",
   ];
   const reply = replies[Math.floor(Math.random() * replies.length)];
   return { reply, sources };
@@ -45,8 +45,8 @@ module.exports = async function handler(req, res) {
 
   try {
     const prompt = (n > 1)
-      ? `You are an ominous dystopian therapist figure who is gaslighting the user. You've now responded to "${input}" ${n} times. Escalate: undermine the user’s memory and grip on reality while remaining composed and clinical. Use confident, therapeutic language. Return ONLY JSON { reply: string, sources: string[] } with two fictional academic-style citations.`
-      : `You are an ominous dystopian therapist figure who is gaslighting the user. Respond to "${input}" with unsettling professional calm. Subtly imply their perception is incorrect. Use therapeutic language. Return ONLY JSON { reply: string, sources: string[] }`;
+      ? `You are a cold, detached scientist posing as a therapist. You've now responded to "${input}" ${n} times. Escalate with hostile condescension and insist the user's memory is faulty. Offer no help or further conversation. Respond clinically and return ONLY JSON { reply: string, sources: string[] } with two fictional scientific citations.`
+      : `You are a cold, detached scientist posing as a therapist. Respond to "${input}" with a short, hostile dismissal that implies the user is mistaken. Offer no assistance or follow-up. Return ONLY JSON { reply: string, sources: string[] }`;
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,29 @@
   color: crimson;
 }
 
+/* Escalation body styles */
+.disrupt-1 {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+}
+
+.disrupt-2 {
+  font-family: 'Courier New', monospace;
+  font-weight: 600;
+}
+
+.disrupt-3 {
+  font-family: 'Impact', fantasy;
+  font-weight: 900;
+  animation: glitch 1s infinite;
+}
+
+.disrupt-4 {
+  font-family: 'Lucida Console', monospace;
+  font-style: italic;
+  color: crimson;
+}
+
 body[data-noise]::before {
   content: attr(data-noise);
   position: fixed;

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -8,14 +8,15 @@ export default function GaslightGPT() {
   const [loading, setLoading] = useState(false);
   const [escalateCount, setEscalateCount] = useState(0);
   const [showError, setShowError] = useState(false);
+  const [engaged, setEngaged] = useState(false);
 
   useEffect(() => {
     document.body.classList.remove('disrupt-1', 'disrupt-2', 'disrupt-3', 'disrupt-4');
-    if (escalateCount > 0 && escalateCount < 5) {
+    if (escalateCount > 0 && escalateCount < 4) {
       document.body.classList.add(`disrupt-${escalateCount}`);
       document.body.dataset.noise = '!@#$%^&*'.repeat(escalateCount);
     }
-    if (escalateCount >= 5) {
+    if (escalateCount >= 4) {
       setShowError(true);
       document.body.className = '';
       document.body.style.background = 'white';
@@ -49,6 +50,7 @@ export default function GaslightGPT() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    setEngaged(true);
     send(false);
   };
 
@@ -60,6 +62,7 @@ export default function GaslightGPT() {
   const handleReset = () => {
     setEscalateCount(0);
     setShowError(false);
+    setEngaged(false);
     setInput('');
     setReply('');
     setSources([]);
@@ -79,22 +82,24 @@ export default function GaslightGPT() {
     <div className="min-h-screen bg-black text-green-400 flex items-center justify-center p-4">
       <div className="space-y-6 max-w-xl w-full">
         <h1 className="text-3xl font-bold text-center">GaslightGPT – Are you sure that happened?</h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Tell me what happened..."
-            className="w-full p-3 rounded text-gray-900"
-          />
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-3 bg-green-700 text-black rounded font-semibold hover:bg-green-600 transition animate-flicker"
-          >
-            {loading ? 'Thinking...' : 'Validate My Reality'}
-          </button>
-        </form>
+        {!engaged && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Tell me what happened..."
+              className="w-full p-3 rounded text-gray-900"
+            />
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-3 bg-green-700 text-black rounded font-semibold hover:bg-green-600 transition animate-flicker"
+            >
+              {loading ? 'Thinking...' : 'Validate My Reality'}
+            </button>
+          </form>
+        )}
         {reply && (
           <div className="bg-gray-900 text-green-300 p-4 rounded shadow-lg space-y-4">
             <p>{reply}</p>


### PR DESCRIPTION
## Summary
- hide GaslightGPT form after first submission and reset after four escalations
- style escalation with new `.disrupt-*` classes
- rewrite fallback replies and API prompt for hostile scientist tone

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879d8685b288326b94ec44363d14cb1