### PR TITLE
Improve GaslightGPT escalation flow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -38,23 +38,32 @@
 .disrupt-1 {
   font-family: 'Georgia', serif;
   font-weight: 700;
+  transition: transform 0.3s ease;
 }
 
 .disrupt-2 {
   font-family: 'Courier New', monospace;
   font-weight: 600;
+  transform: skewX(-5deg);
+  transition: transform 0.3s ease;
 }
 
 .disrupt-3 {
   font-family: 'Impact', fantasy;
   font-weight: 900;
-  animation: glitch 1s infinite;
+  animation: glitch 0.7s infinite;
+  transform: skewX(-10deg) rotate(-2deg) scale(1.02);
+  filter: hue-rotate(45deg);
+  transition: transform 0.3s ease;
 }
 
 .disrupt-4 {
   font-family: 'Lucida Console', monospace;
   font-style: italic;
   color: crimson;
+  transform: skewX(-15deg) rotate(-5deg) scale(1.05);
+  filter: hue-rotate(180deg) invert(1);
+  transition: transform 0.3s ease;
 }
 
 body[data-noise]::before {

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -9,6 +9,10 @@ export default function GaslightGPT() {
   const [escalateCount, setEscalateCount] = useState(0);
   const [showError, setShowError] = useState(false);
   const [engaged, setEngaged] = useState(false);
+  const escalateLabel =
+    reply && reply.toLowerCase().includes('not possible')
+      ? "Yeah, it's possible and it happened"
+      : 'I remember it differently';
 
   useEffect(() => {
     document.body.classList.remove('disrupt-1', 'disrupt-2', 'disrupt-3', 'disrupt-4');
@@ -100,12 +104,15 @@ export default function GaslightGPT() {
             </button>
           </form>
         )}
+        {engaged && loading && !reply && (
+          <div className="text-center animate-pulse">Loading...</div>
+        )}
         {reply && (
           <div className="bg-gray-900 text-green-300 p-4 rounded shadow-lg space-y-4">
             <p>{reply}</p>
             <div className="flex space-x-4">
               <button onClick={() => setShowSources(true)} className="underline hover:text-green-500">Show Sources</button>
-              <button onClick={handleEscalate} className="underline hover:text-green-500">I remember it differently</button>
+              <button onClick={handleEscalate} className="underline hover:text-green-500">{escalateLabel}</button>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- intensify `disrupt-*` classes so the page skews and glitches when escalating
- show a loading message while GaslightGPT waits for the response
- adapt escalation button text to contradict the denial from the scientist

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879daf689f88326bc1eda27eabedc99