### PR TITLE
Add expected reply support to GaslightGPT

### DIFF
--- a/api/gaslight.js
+++ b/api/gaslight.js
@@ -1,23 +1,41 @@
 const fallbackGaslight = (input, n) => {
   const escalate = n > 1;
-  const replies = escalate
+  const options = escalate
     ? [
-        "We've already covered this. Your recollection is clearly erroneous.",
-        "Once again, your memory fails you. Accept the facts.",
-        "It's pointless to continue. You're fabricating things now.",
+        {
+          reply: "We've already covered this. Your recollection is clearly erroneous.",
+          expected: "No, I remember it perfectly. Why won't you admit it?",
+        },
+        {
+          reply: "Once again, your memory fails you. Accept the facts.",
+          expected: "I'm not wrong. You're twisting things!",
+        },
+        {
+          reply: "It's pointless to continue. You're fabricating things now.",
+          expected: "You're the one fabricating! I know the truth.",
+        },
       ]
     : [
-        "That's not what happened, and you know it.",
-        "Your perception is obviously skewed.",
-        "I doubt your account matches reality.",
+        {
+          reply: "That's not what happened, and you know it.",
+          expected: "Yes it is. Don't gaslight me.",
+        },
+        {
+          reply: "Your perception is obviously skewed.",
+          expected: "My perception is fine. You're lying.",
+        },
+        {
+          reply: "I doubt your account matches reality.",
+          expected: "It absolutely does. Stop denying it.",
+        },
       ];
   const sources = [
     "Institute for Recollection Studies, 2024",
     "Journal of Memory Correction, Vol. 12",
     "Classified Report 88-B",
   ];
-  const reply = replies[Math.floor(Math.random() * replies.length)];
-  return { reply, sources };
+  const { reply, expected } = options[Math.floor(Math.random() * options.length)];
+  return { reply, expected, sources };
 };
 
 module.exports = async function handler(req, res) {
@@ -45,8 +63,8 @@ module.exports = async function handler(req, res) {
 
   try {
     const prompt = (n > 1)
-      ? `You are a cold, detached scientist posing as a therapist. You've now responded to "${input}" ${n} times. Escalate with hostile condescension and insist the user's memory is faulty. Offer no help or further conversation. Respond clinically and return ONLY JSON { reply: string, sources: string[] } with two fictional scientific citations.`
-      : `You are a cold, detached scientist posing as a therapist. Respond to "${input}" with a short, hostile dismissal that implies the user is mistaken. Offer no assistance or follow-up. Return ONLY JSON { reply: string, sources: string[] }`;
+      ? `You are a cold, detached scientist posing as a therapist. You've now responded to "${input}" ${n} times. Escalate with hostile condescension and insist the user's memory is faulty. Offer no help or further conversation. Respond clinically and return ONLY JSON { reply: string, expected: string, sources: string[] } with two fictional scientific citations. The expected field is a short objection the user might give in response to your statement.`
+      : `You are a cold, detached scientist posing as a therapist. Respond to "${input}" with a short, hostile dismissal that implies the user is mistaken. Offer no assistance or follow-up. Return ONLY JSON { reply: string, expected: string, sources: string[] }. The expected field is a short objection the user might say.`;
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -4,6 +4,7 @@ export default function GaslightGPT() {
   const [input, setInput] = useState('');
   const [reply, setReply] = useState('');
   const [sources, setSources] = useState([]);
+  const [expected, setExpected] = useState('');
   const [showSources, setShowSources] = useState(false);
   const [loading, setLoading] = useState(false);
   const [escalateCount, setEscalateCount] = useState(0);
@@ -44,6 +45,7 @@ export default function GaslightGPT() {
       const data = await res.json();
       setReply(data.reply || '');
       setSources(data.sources || []);
+      setExpected(data.expected || '');
       setShowSources(false);
     } catch (err) {
       console.error(err);
@@ -70,6 +72,7 @@ export default function GaslightGPT() {
     setInput('');
     setReply('');
     setSources([]);
+    setExpected('');
     setShowSources(false);
   };
 
@@ -113,6 +116,17 @@ export default function GaslightGPT() {
             <div className="flex space-x-4">
               <button onClick={() => setShowSources(true)} className="underline hover:text-green-500">Show Sources</button>
               <button onClick={handleEscalate} className="underline hover:text-green-500">{escalateLabel}</button>
+              {expected && (
+                <button
+                  onClick={() => {
+                    setInput(expected);
+                    handleEscalate();
+                  }}
+                  className="underline hover:text-green-500"
+                >
+                  {expected}
+                </button>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- extend `gaslight` API to include an `expected` field suggesting a user objection
- tweak OpenAI prompt and fallback generator for the new field
- show the suggested objection in the GaslightGPT UI as a clickable option

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879dcd5d8748326b8fd924e07336463