### PR TITLE
Refine GaslightGPT escalation UX

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -35,35 +35,47 @@
 }
 
 /* Escalation body styles */
-.disrupt-1 {
+.disrupt-1 *:nth-child(3n) {
   font-family: 'Georgia', serif;
   font-weight: 700;
-  transition: transform 0.3s ease;
 }
 
-.disrupt-2 {
+.disrupt-1 {
+  animation: flicker 1s infinite;
+}
+
+.disrupt-2 *:nth-child(4n) {
   font-family: 'Courier New', monospace;
   font-weight: 600;
   transform: skewX(-5deg);
-  transition: transform 0.3s ease;
 }
 
-.disrupt-3 {
+.disrupt-2 {
+  animation: flicker 0.5s infinite;
+}
+
+.disrupt-3 *:nth-child(odd) {
   font-family: 'Impact', fantasy;
   font-weight: 900;
   animation: glitch 0.7s infinite;
   transform: skewX(-10deg) rotate(-2deg) scale(1.02);
   filter: hue-rotate(45deg);
-  transition: transform 0.3s ease;
 }
 
-.disrupt-4 {
+.disrupt-3 {
+  animation: flicker 0.3s infinite;
+}
+
+.disrupt-4 *:nth-child(2n + 1) {
   font-family: 'Lucida Console', monospace;
   font-style: italic;
   color: crimson;
   transform: skewX(-15deg) rotate(-5deg) scale(1.05);
   filter: hue-rotate(180deg) invert(1);
-  transition: transform 0.3s ease;
+}
+
+.disrupt-4 {
+  animation: flicker 0.15s infinite;
 }
 
 body[data-noise]::before {

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -10,16 +10,13 @@ export default function GaslightGPT() {
   const [escalateCount, setEscalateCount] = useState(0);
   const [showError, setShowError] = useState(false);
   const [engaged, setEngaged] = useState(false);
-  const escalateLabel =
-    reply && reply.toLowerCase().includes('not possible')
-      ? "Yeah, it's possible and it happened"
-      : 'I remember it differently';
 
   useEffect(() => {
     document.body.classList.remove('disrupt-1', 'disrupt-2', 'disrupt-3', 'disrupt-4');
     if (escalateCount > 0 && escalateCount < 4) {
       document.body.classList.add(`disrupt-${escalateCount}`);
-      document.body.dataset.noise = '!@#$%^&*'.repeat(escalateCount);
+      document.body.dataset.noise =
+        '!@#$%^&*✶✷✸✹☠☢☣☤'.repeat(escalateCount * 2);
     }
     if (escalateCount >= 4) {
       setShowError(true);
@@ -114,8 +111,14 @@ export default function GaslightGPT() {
           <div className="bg-gray-900 text-green-300 p-4 rounded shadow-lg space-y-4">
             <p>{reply}</p>
             <div className="flex space-x-4">
-              <button onClick={() => setShowSources(true)} className="underline hover:text-green-500">Show Sources</button>
-              <button onClick={handleEscalate} className="underline hover:text-green-500">{escalateLabel}</button>
+              {escalateCount > 1 && (
+                <button
+                  onClick={() => setShowSources(true)}
+                  className="underline hover:text-green-500"
+                >
+                  Show Sources
+                </button>
+              )}
               {expected && (
                 <button
                   onClick={() => {


### PR DESCRIPTION
## Summary
- randomize fonts during disruption stages instead of changing them all at once
- show a single objection button with the optional Sources button after n > 1
- start flicker effects earlier and add more noise characters

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879df203b448326a5c2b797607c87b9