### PR TITLE
Fix styling escalation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -35,47 +35,26 @@
 }
 
 /* Escalation body styles */
-.disrupt-1 *:nth-child(3n) {
+.disrupt-1 {
   font-family: 'Georgia', serif;
   font-weight: 700;
 }
 
-.disrupt-1 {
-  animation: flicker 1s infinite;
-}
-
-.disrupt-2 *:nth-child(4n) {
+.disrupt-2 {
   font-family: 'Courier New', monospace;
   font-weight: 600;
-  transform: skewX(-5deg);
-}
-
-.disrupt-2 {
-  animation: flicker 0.5s infinite;
-}
-
-.disrupt-3 *:nth-child(odd) {
-  font-family: 'Impact', fantasy;
-  font-weight: 900;
-  animation: glitch 0.7s infinite;
-  transform: skewX(-10deg) rotate(-2deg) scale(1.02);
-  filter: hue-rotate(45deg);
 }
 
 .disrupt-3 {
-  animation: flicker 0.3s infinite;
-}
-
-.disrupt-4 *:nth-child(2n + 1) {
-  font-family: 'Lucida Console', monospace;
-  font-style: italic;
-  color: crimson;
-  transform: skewX(-15deg) rotate(-5deg) scale(1.05);
-  filter: hue-rotate(180deg) invert(1);
+  font-family: 'Impact', fantasy;
+  font-weight: 900;
+  animation: glitch 1s infinite;
 }
 
 .disrupt-4 {
-  animation: flicker 0.15s infinite;
+  font-family: 'Lucida Console', monospace;
+  font-style: italic;
+  color: crimson;
 }
 
 body[data-noise]::before {

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -15,8 +15,7 @@ export default function GaslightGPT() {
     document.body.classList.remove('disrupt-1', 'disrupt-2', 'disrupt-3', 'disrupt-4');
     if (escalateCount > 0 && escalateCount < 4) {
       document.body.classList.add(`disrupt-${escalateCount}`);
-      document.body.dataset.noise =
-        '!@#$%^&*✶✷✸✹☠☢☣☤'.repeat(escalateCount * 2);
+      document.body.dataset.noise = '!@#$%^&*'.repeat(escalateCount);
     }
     if (escalateCount >= 4) {
       setShowError(true);
@@ -27,6 +26,12 @@ export default function GaslightGPT() {
       document.body.style.background = '';
       if (escalateCount === 0) delete document.body.dataset.noise;
     }
+
+    return () => {
+      document.body.classList.remove('disrupt-1', 'disrupt-2', 'disrupt-3', 'disrupt-4');
+      document.body.style.background = '';
+      delete document.body.dataset.noise;
+    };
   }, [escalateCount]);
 
   const send = async (escalate = false) => {


### PR DESCRIPTION
## Summary
- streamline escalation classes in CSS
- simplify GaslightGPT noise effect and clean up styles on unmount

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879e23629f08326b91622e370cfaf29