### PR TITLE
Refine GaslightGPT escalation effects

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,19 +6,19 @@
 .phase-1 {
   font-family: "Georgia", serif;
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .phase-2 {
   font-family: "Courier New", monospace;
   font-weight: 600;
-  font-size: 1.25rem;
+  font-size: 1.50rem;
 }
 
 .phase-3 {
   font-family: "Impact", fantasy;
   font-weight: 900;
-  font-size: 1.25rem;
+  font-size: .25rem;
   letter-spacing: 1px;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -6,26 +6,26 @@
 .phase-1 {
   font-family: "Georgia", serif;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 2.5rem;
 }
 
 .phase-2 {
   font-family: "Courier New", monospace;
   font-weight: 600;
-  font-size: 1.50rem;
+  font-size: 2.5rem;
 }
 
 .phase-3 {
   font-family: "Impact", fantasy;
   font-weight: 900;
-  font-size: .25rem;
+  font-size: 2.5rem;
   letter-spacing: 1px;
 }
 
 .phase-4 {
   font-family: "Lucida Console", monospace;
   font-style: italic;
-  font-size: 1.25rem;
+  font-size: 2.5rem;
 }
 
 .phase-5 {

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 .phase-1 {
   font-family: "Georgia", serif;
   font-weight: 700;
-  font-size: 2.5rem;
+  font-size: 2rem;
 }
 
 .phase-2 {
@@ -25,7 +25,7 @@
 .phase-4 {
   font-family: "Lucida Console", monospace;
   font-style: italic;
-  font-size: 2.5rem;
+  font-size: 2.75rem;
 }
 
 .phase-5 {

--- a/src/index.css
+++ b/src/index.css
@@ -6,26 +6,26 @@
 .phase-1 {
   font-family: "Georgia", serif;
   font-weight: 700;
-  font-size: 2rem;
+  font-size: 1.25rem;
 }
 
 .phase-2 {
   font-family: "Courier New", monospace;
   font-weight: 600;
-  font-size: 2.25rem;
+  font-size: 1.25rem;
 }
 
 .phase-3 {
   font-family: "Impact", fantasy;
   font-weight: 900;
-  font-size: 2.5rem;
+  font-size: 1.25rem;
   letter-spacing: 1px;
 }
 
 .phase-4 {
   font-family: "Lucida Console", monospace;
   font-style: italic;
-  font-size: 2.75rem;
+  font-size: 1.25rem;
 }
 
 .phase-5 {
@@ -81,15 +81,19 @@ body[data-noise]::before {
 }
 
 .meltdown {
-  transform: rotate(1deg) skewX(15deg) skewY(10deg);
-  animation: meltdownAnim 0.4s infinite alternate ease-in-out;
+  transform: skewX(15deg) skewY(10deg);
 }
 
-@keyframes meltdownAnim {
-  0% {
-    transform: rotate(1deg) skewX(15deg) skewY(10deg);
+.wavy {
+  display: inline-block;
+  animation: wavy 0.8s infinite ease-in-out;
+}
+
+@keyframes wavy {
+  0%, 100% {
+    transform: translateY(0);
   }
-  100% {
-    transform: rotate(-1deg) skewX(-15deg) skewY(-10deg);
+  50% {
+    transform: translateY(-3px);
   }
 }

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -9,6 +9,7 @@ export default function GaslightGPT() {
   const [firstInteraction, setFirstInteraction] = useState(true);
   const [escalateCount, setEscalateCount] = useState(0);
   const [showError, setShowError] = useState(false);
+  const [wavyIndices, setWavyIndices] = useState([]);
 
   useEffect(() => {
     const allClasses = [
@@ -56,9 +57,21 @@ export default function GaslightGPT() {
       });
       const data = await res.json();
       setReply(data.reply || "");
-      setExpected(
-        [data.expected1, data.expected2, data.expected3].filter(Boolean)
-      );
+      const expList = [
+        data.expected1,
+        data.expected2,
+        data.expected3,
+      ].filter(Boolean);
+      setExpected(expList);
+      if (level > 0 && level < 5) {
+        const indices = [];
+        expList.forEach((_, i) => {
+          if (Math.random() < 0.5) indices.push(i);
+        });
+        setWavyIndices(indices);
+      } else {
+        setWavyIndices([]);
+      }
       setSources(data.sources || []);
       setEscalateCount(level);
     } catch (err) {
@@ -87,6 +100,7 @@ export default function GaslightGPT() {
     setReply("");
     setExpected([]);
     setSources([]);
+    setWavyIndices([]);
     setEscalateCount(0);
     setShowError(false);
     setFirstInteraction(true);
@@ -147,13 +161,14 @@ export default function GaslightGPT() {
                   "text-blue-300 hover:text-blue-500",
                   "text-pink-300 hover:text-pink-500",
                 ];
+                const wavy = wavyIndices.includes(i) ? "wavy" : "";
                 return (
                   <button
                     key={i}
                     onClick={handleEscalate}
                     className={`underline whitespace-nowrap ${
                       colors[i % colors.length]
-                    }`}
+                    } ${wavy}`}
                   >
                     {e}
                   </button>


### PR DESCRIPTION
## Summary
- keep text size stable until the final meltdown stage
- skew the meltdown state without wavy animation
- add random wavy effect on some escalation buttons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a854505808326a4281d1696e16f4f