### PR TITLE
Conditionally wrap expected replies

### DIFF
--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -166,9 +166,9 @@ export default function GaslightGPT() {
                   <button
                     key={i}
                     onClick={handleEscalate}
-                    className={`underline whitespace-nowrap ${
-                      colors[i % colors.length]
-                    } ${wavy}`}
+                    className={`underline ${
+                      escalateCount >= 4 ? "whitespace-nowrap" : ""
+                    } ${colors[i % colors.length]} ${wavy}`}
                   >
                     {e}
                   </button>


### PR DESCRIPTION
## Summary
- wrap expected reply text on GaslightGPT for stages 1-3

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a8e7525f88326b0e50fa668536054