### PR TITLE
Revamp glitch effects

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,19 +43,16 @@ body {
 .disrupt-1 {
   font-family: "Georgia", serif;
   font-weight: 700;
-  transform: skewX(3deg) skewY(2deg);
 }
 
 .disrupt-2 {
   font-family: "Courier New", monospace;
   font-weight: 600;
-  transform: skewX(6deg) skewY(4deg);
 }
 
 .disrupt-3 {
   font-family: "Impact", fantasy;
   font-weight: 900;
-  transform: skewX(9deg) skewY(6deg);
   animation: glitch 1s infinite;
 }
 
@@ -63,7 +60,6 @@ body {
   font-family: "Lucida Console", monospace;
   font-style: italic;
   color: crimson;
-  transform: skewX(12deg) skewY(8deg);
 }
 
 body[data-noise]::before {
@@ -91,6 +87,25 @@ body[data-noise]::before {
 
 .meltdown {
   transform: skewX(15deg) skewY(10deg);
+}
+
+.static-flicker::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(0deg, rgba(255,255,255,0.05) 0, rgba(255,255,255,0.05) 2px, transparent 2px, transparent 4px),
+    repeating-linear-gradient(90deg, rgba(0,0,0,0.05) 0, rgba(0,0,0,0.05) 2px, transparent 2px, transparent 4px);
+  animation: static-flicker 0.2s steps(2, end) infinite;
+}
+
+@keyframes static-flicker {
+  0%, 100% { opacity: 0.15; }
+  50% { opacity: 0.3; }
 }
 
 .wavy {

--- a/src/pages/GaslightGPT.jsx
+++ b/src/pages/GaslightGPT.jsx
@@ -1,5 +1,14 @@
 import { useState, useEffect } from "react";
 
+function generateNoise(level) {
+  const chars = "!@#$%^&*()_+-=[]{}|;:'\"<>,.?/";
+  let out = "";
+  for (let i = 0; i < level * 20; i++) {
+    out += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return out;
+}
+
 export default function GaslightGPT() {
   const [input, setInput] = useState("");
   const [reply, setReply] = useState("");
@@ -22,6 +31,7 @@ export default function GaslightGPT() {
       "disrupt-2",
       "disrupt-3",
       "disrupt-4",
+      "static-flicker",
       "meltdown",
     ];
     document.body.classList.remove(...allClasses);
@@ -30,7 +40,10 @@ export default function GaslightGPT() {
     if (escalateCount >= 1 && escalateCount <= 4) {
       document.body.classList.add(`disrupt-${escalateCount}`);
       document.body.classList.add(`phase-${escalateCount}`);
-      document.body.dataset.noise = "!@#$%^&*".repeat(escalateCount);
+      document.body.dataset.noise = generateNoise(escalateCount);
+      if (escalateCount >= 3) {
+        document.body.classList.add("static-flicker");
+      }
     }
 
     if (escalateCount === 5) {
@@ -108,12 +121,13 @@ export default function GaslightGPT() {
 
   if (showError) {
     return (
-      <div className="min-h-screen bg-white text-black flex flex-col items-center justify-center p-4">
-        <p className="mb-4 text-center">
-          Error Code 480 - Maximum Number of Realities Exceeded
+      <div className="min-h-screen bg-gray-100 text-gray-700 flex flex-col items-center justify-center p-6">
+        <div className="text-7xl mb-4">:(</div>
+        <p className="mb-6 text-center max-w-md">
+          Chrome ran out of memory while trying to display this page.
         </p>
-        <button onClick={handleReset} className="border px-4 py-2">
-          let's start from the beginning
+        <button onClick={handleReset} className="border px-4 py-2 bg-white">
+          restart
         </button>
       </div>
     );


### PR DESCRIPTION
## Summary
- overhaul glitch escalation logic
- randomize character noise and add static overlay
- move skew to meltdown state only
- update meltdown error screen to mimic a browser crash

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687aadb751f483269717d965de06dc25