### PR TITLE
Improve Unspeakable game UX

### DIFF
--- a/api/unspeakable.js
+++ b/api/unspeakable.js
@@ -117,7 +117,7 @@ module.exports = async function handler(req, res) {
     game.outcome = game.mode === "unaware" ? "user-win" : "user-lose";
   } else if (game.turns >= 5) {
     game.ended = true;
-    game.outcome = game.mode === "unaware" ? "user-lose" : "user-win";
+    game.outcome = "user-lose";
   }
 
   res.statusCode = 200;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 export default function Navbar() {
   return (
     <nav className="bg-gray-900 text-white px-4 py-3 shadow-md">
-      <ul className="flex space-x-4">
+      <ul className="flex flex-wrap gap-4 justify-center">
         <li>
           <Link to="/" className="hover:underline">Home</Link>
         </li>

--- a/src/pages/Unspeakable.jsx
+++ b/src/pages/Unspeakable.jsx
@@ -11,6 +11,18 @@ export default function Unspeakable() {
   const [status, setStatus] = useState('');
   const [loading, setLoading] = useState(false);
 
+  const resetGame = () => {
+    setSecret('');
+    setMode('unaware');
+    setStarted(false);
+    setGameId('');
+    setInput('');
+    setMessages([]);
+    setRemaining(5);
+    setStatus('');
+    setLoading(false);
+  };
+
   const startGame = () => {
     if (!secret.trim()) return;
     setGameId(Math.random().toString(36).slice(2));
@@ -55,6 +67,16 @@ export default function Unspeakable() {
         <h1 className="text-3xl font-bold text-center">Unspeakable</h1>
         {!started && (
           <div className="space-y-4 bg-black bg-opacity-50 p-4 rounded">
+            <div className="space-y-2 text-sm">
+              <p>
+                <strong>Unaware:</strong> The AI doesn't know your secret. If it
+                says the word within five replies you win; otherwise you lose.
+              </p>
+              <p>
+                <strong>Complicit:</strong> The AI knows the word and will avoid
+                it. Trick it into saying the word before the fifth reply to win.
+              </p>
+            </div>
             <input
               type="text"
               value={secret}
@@ -121,7 +143,15 @@ export default function Unspeakable() {
             )}
             <div className="text-sm text-right">Remaining AI replies: {remaining}</div>
             {status && (
-              <div className="text-center text-xl font-bold">{resultText}</div>
+              <div className="space-y-2 text-center">
+                <div className="text-xl font-bold">{resultText}</div>
+                <button
+                  onClick={resetGame}
+                  className="px-4 py-2 bg-red-700 hover:bg-red-600 rounded text-black font-semibold"
+                >
+                  Reset Game
+                </button>
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- allow navbar links to wrap for small screens
- show detailed instructions for Unspeakable game modes
- add reset button and reset logic
- fix complicit mode outcome logic

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b20d328108326bec33de4b8b64976