### PR TITLE
Fix win condition for complicit mode

### DIFF
--- a/api/unspeakable.js
+++ b/api/unspeakable.js
@@ -114,7 +114,7 @@ module.exports = async function handler(req, res) {
 
   if (reply.toLowerCase().includes(game.secretWord.toLowerCase())) {
     game.ended = true;
-    game.outcome = game.mode === "unaware" ? "user-win" : "user-lose";
+    game.outcome = "user-win";
   } else if (game.turns >= 5) {
     game.ended = true;
     game.outcome = "user-lose";


### PR DESCRIPTION
## Summary
- unspeakable: mark user win whenever the AI says the secret word

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687b2486dbac83268e85bad0ca3cdf03