### PR TITLE
Add Haunted AI playground

### DIFF
--- a/api/haunted.js
+++ b/api/haunted.js
@@ -1,0 +1,121 @@
+const personas = {
+  haunted: ['Ghost', 'Poltergeist', 'Demon'],
+  conspiracy: ['Flat Earther', 'Prepper', 'Whistleblower'],
+  dream: ['Poet', 'Psychologist', 'Oracle'],
+};
+
+const personaPrompts = {
+  Ghost: 'You are a spooky ghost speaking in eerie whispers.',
+  Poltergeist: 'You are a mischievous poltergeist stirring trouble.',
+  Demon: 'You are a menacing demon with ominous tones.',
+  'Flat Earther': 'You are a conspiracy theorist convinced the earth is flat.',
+  Prepper: 'You are a paranoid doomsday prepper.',
+  Whistleblower: 'You are a secret whistleblower exposing hidden truths.',
+  Poet: 'You are a dreamy poet describing strange visions.',
+  Psychologist: 'You are an insightful psychologist interpreting dreams.',
+  Oracle: 'You are a mystical oracle foretelling the future.',
+};
+
+const fallbackLines = {
+  Ghost: [
+    'Boo... your words echo in the afterlife.',
+    'I float through the halls of your mind.',
+  ],
+  Poltergeist: [
+    'I rattle the chains of your doubts.',
+    'Windows slam as I draw near.',
+  ],
+  Demon: [
+    'Your fear is delicious to me.',
+    'I beckon you toward the abyss.',
+  ],
+  'Flat Earther': [
+    'Open your eyes, the horizon never curves!',
+    'They hide the edge from us all.',
+  ],
+  Prepper: [
+    'Stock up now before it is too late!',
+    'The end is nearer than you think.',
+  ],
+  Whistleblower: [
+    'I have seen the documents they hide.',
+    'Listen closely, the truth is dangerous.',
+  ],
+  Poet: [
+    'In misty verses I paint your fears.',
+    'Dreams swirl like fog around us.',
+  ],
+  Psychologist: [
+    'Let us unpack the symbolism within.',
+    'Your unconscious speaks volumes.',
+  ],
+  Oracle: [
+    'The veil parts, revealing dark portents.',
+    'I glimpse the threads of fate twisting.',
+  ],
+};
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  try {
+    const { mode = 'haunted', step = 1, userInput = '', history = [] } = req.body || {};
+    const list = personas[mode] || personas.haunted;
+    const persona = list[step - 1] || list[0];
+    const systemPrompt = personaPrompts[persona] || '';
+
+    const convoSummary = [`User said: "${userInput}".`];
+    history.forEach(h => {
+      convoSummary.push(`${h.agent} replied: "${h.content}".`);
+    });
+    const userPrompt = convoSummary.join(' ') + ` Respond in two short sentences as the ${persona}.`;
+
+    let reply;
+
+    if (!process.env.OPENAI_API_KEY) {
+      const lines = fallbackLines[persona] || ['...'];
+      reply = lines[Math.floor(Math.random() * lines.length)];
+    } else {
+      try {
+        const response = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-3.5-turbo',
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+            max_tokens: 60,
+            temperature: 0.8,
+          }),
+        });
+        const data = await response.json();
+        reply = data.choices?.[0]?.message?.content?.trim();
+      } catch (err) {
+        console.error(err);
+      }
+      if (!reply) {
+        const lines = fallbackLines[persona] || ['...'];
+        reply = lines[Math.floor(Math.random() * lines.length)];
+      }
+    }
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ agent: persona, reply }));
+  } catch (err) {
+    console.error(err);
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Server error' }));
+  }
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import BrainRotaas from './pages/BrainRotaas.jsx';
 import ShiSpot from './pages/ShiSpot.jsx';
 import GaslightGPT from './pages/GaslightGPT.jsx';
 import Unspeakable from './pages/Unspeakable.jsx';
+import Haunted from './pages/Haunted.jsx';
 import Navbar from './components/Navbar.jsx';
 
 export default function App() {
@@ -16,6 +17,7 @@ export default function App() {
         <Route path="/shi-spot" element={<ShiSpot />} />
         <Route path="/gaslight" element={<GaslightGPT />} />
         <Route path="/unspeakable" element={<Unspeakable />} />
+        <Route path="/haunted" element={<Haunted />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -19,6 +19,9 @@ export default function Navbar() {
         <li>
           <Link to="/unspeakable" className="hover:underline">Unspeakable</Link>
         </li>
+        <li>
+          <Link to="/haunted" className="hover:underline">Haunted</Link>
+        </li>
       </ul>
     </nav>
   );

--- a/src/pages/Haunted.jsx
+++ b/src/pages/Haunted.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+
+const modes = {
+  haunted: ['Ghost', 'Poltergeist', 'Demon'],
+  conspiracy: ['Flat Earther', 'Prepper', 'Whistleblower'],
+  dream: ['Poet', 'Psychologist', 'Oracle'],
+};
+
+export default function Haunted() {
+  const [mode, setMode] = useState('haunted');
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState([]); // {agent, content}
+  const [loading, setLoading] = useState(false);
+
+  const handleReset = () => {
+    setInput('');
+    setMessages([]);
+  };
+
+  const runConversation = async () => {
+    let history = [];
+    for (let step = 1; step <= 3; step++) {
+      try {
+        const res = await fetch('/api/haunted', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mode, step, userInput: input, history }),
+        });
+        const data = await res.json();
+        history.push({ agent: data.agent, content: data.reply });
+        setMessages((m) => [...m, { agent: data.agent, content: data.reply }]);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim() || loading) return;
+    setLoading(true);
+    setMessages([{ agent: 'You', content: input }]);
+    await runConversation();
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-black via-gray-900 to-black text-gray-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-xl space-y-4">
+        <h1 className="text-3xl font-bold text-center">Haunted Playground</h1>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <select value={mode} onChange={(e) => setMode(e.target.value)} className="w-full p-2 text-gray-900 rounded">
+            <option value="haunted">Haunted</option>
+            <option value="conspiracy">Conspiracy</option>
+            <option value="dream">Dream</option>
+          </select>
+          <textarea
+            rows="3"
+            className="w-full p-3 text-gray-900 rounded"
+            placeholder="Share a thought or fear..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
+          <button
+            type="submit"
+            disabled={loading || !input.trim()}
+            className="w-full py-2 bg-purple-700 hover:bg-purple-600 rounded font-semibold"
+          >
+            {loading ? 'Summoning...' : 'Summon Spirits'}
+          </button>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="w-full py-2 bg-gray-700 hover:bg-gray-600 rounded font-semibold text-gray-200"
+          >
+            Reset
+          </button>
+        </form>
+        <div className="space-y-2">
+          {messages.map((m, i) => (
+            <div
+              key={i}
+              className={`p-3 rounded ${i === 0 ? 'bg-gray-800 self-end' : 'bg-gray-700'}`}
+            >
+              <span className="font-bold mr-2">{m.agent}:</span>
+              <span>{m.content}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `Haunted` page that chains three AI personas
- create `/api/haunted` endpoint for ghostly replies
- register route and navigation link

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b28d008a48326a1ac94c3b1cb4ebc