### PR TITLE
Add chat-like typewriter to Haunted page

### DIFF
--- a/src/components/Typewriter.jsx
+++ b/src/components/Typewriter.jsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+export default function Typewriter({ text = '', speed = 30, onDone }) {
+  const [display, setDisplay] = useState('');
+
+  useEffect(() => {
+    let i = 0;
+    setDisplay('');
+    const id = setInterval(() => {
+      setDisplay(text.slice(0, i + 1));
+      i += 1;
+      if (i === text.length) {
+        clearInterval(id);
+        if (onDone) onDone();
+      }
+    }, speed);
+    return () => clearInterval(id);
+  }, [text, speed, onDone]);
+
+  return <span>{display}</span>;
+}

--- a/src/pages/Haunted.jsx
+++ b/src/pages/Haunted.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Typewriter from '../components/Typewriter';
 
 const modes = {
   haunted: ['Ghost', 'Poltergeist', 'Demon'],
@@ -83,7 +84,7 @@ export default function Haunted() {
               className={`p-3 rounded ${i === 0 ? 'bg-gray-800 self-end' : 'bg-gray-700'}`}
             >
               <span className="font-bold mr-2">{m.agent}:</span>
-              <span>{m.content}</span>
+              <Typewriter text={m.content} />
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add a reusable `Typewriter` component
- use the typewriter effect for Haunted Playground replies
- build project to ensure it compiles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b2ba74ed48326b6b8910d8f2039c6