### PR TITLE
Fix re-typing bug in Typewriter

### DIFF
--- a/src/components/Typewriter.jsx
+++ b/src/components/Typewriter.jsx
@@ -1,8 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export default function Typewriter({ text = '', speed = 30, onDone }) {
   const [display, setDisplay] = useState('');
   const [done, setDone] = useState(false);
+  const doneRef = useRef(onDone);
+
+  useEffect(() => {
+    doneRef.current = onDone;
+  }, [onDone]);
 
   useEffect(() => {
     let i = 0;
@@ -14,11 +19,11 @@ export default function Typewriter({ text = '', speed = 30, onDone }) {
       if (i === text.length) {
         clearInterval(id);
         setDone(true);
-        if (onDone) onDone();
+        if (doneRef.current) doneRef.current();
       }
     }, speed);
     return () => clearInterval(id);
-  }, [text, speed, onDone]);
+  }, [text, speed]);
 
   return <span className={done ? '' : 'typing'}>{display}</span>;
 }


### PR DESCRIPTION
## Summary
- fix Typewriter effect resetting when callback reference changed

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bc769b4a4832691b04c957409008c