### PR TITLE
Fix ghost typewriter duplication

### DIFF
--- a/src/pages/Ghost.jsx
+++ b/src/pages/Ghost.jsx
@@ -76,7 +76,7 @@ export default function Ghost() {
           ))}
           {index >= 0 && index < lines.length && (
             <div className="p-3 bg-gray-800 rounded">
-              <Typewriter text={lines[index]} onDone={handleLineDone} />
+              <Typewriter key={index} text={lines[index]} onDone={handleLineDone} />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- update Ghost page so new Typewriter messages don't briefly repeat the previous line

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bc88c9dd88326928871f8c8874905