### PR TITLE
Fix ghost bubble text duplication

### DIFF
--- a/src/components/Typewriter.jsx
+++ b/src/components/Typewriter.jsx
@@ -19,7 +19,7 @@ export default function Typewriter({ text = '', speed = 30, onDone }) {
       if (i === text.length) {
         clearInterval(id);
         setDone(true);
-        if (doneRef.current) doneRef.current();
+        if (doneRef.current) doneRef.current(text);
       }
     }, speed);
     return () => clearInterval(id);

--- a/src/pages/Ghost.jsx
+++ b/src/pages/Ghost.jsx
@@ -39,8 +39,8 @@ export default function Ghost() {
     }
   }, [lines]);
 
-  const handleLineDone = () => {
-    setDisplayed((d) => [...d, lines[index]]);
+  const handleLineDone = (finishedText) => {
+    setDisplayed((d) => [...d, finishedText]);
     setTimeout(() => {
       setIndex((i) => i + 1);
     }, 700);


### PR DESCRIPTION
## Summary
- deliver typed text from `Typewriter` via callback
- ensure `Ghost` page uses the callback argument when adding finished lines

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bca40e6248326b2298aa242df91a2