### PR TITLE
feat: wrap Game of Life grid edges

### DIFF
--- a/src/pages/Life.jsx
+++ b/src/pages/Life.jsx
@@ -29,12 +29,10 @@ export default function Life() {
       return g.map((row, i) =>
         row.map((cell, j) => {
           let neighbors = 0;
-          operations.forEach(([x, y]) => {
-            const newI = i + x;
-            const newJ = j + y;
-            if (newI >= 0 && newI < numRows && newJ >= 0 && newJ < numCols) {
-              neighbors += g[newI][newJ];
-            }
+          operations.forEach(([dx, dy]) => {
+            const newI = (i + dx + numRows) % numRows;
+            const newJ = (j + dy + numCols) % numCols;
+            neighbors += g[newI][newJ];
           });
           if (cell === 1 && (neighbors < 2 || neighbors > 3)) {
             return 0;


### PR DESCRIPTION
## Summary
- allow Game of Life neighbors to wrap across edges using modulo arithmetic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc08002883268cd101e6b2faa67c