### PR TITLE
Add adjustable generation speed slider

### DIFF
--- a/src/pages/Life.jsx
+++ b/src/pages/Life.jsx
@@ -78,8 +78,11 @@ export default function Life() {
   const [running, setRunning] = useState(false);
   const [cellSize, setCellSize] = useState(20);
   const [selectedShape, setSelectedShape] = useState('block');
+  const [interval, setIntervalValue] = useState(500);
   const runningRef = useRef(running);
+  const intervalRef = useRef(interval);
   runningRef.current = running;
+  intervalRef.current = interval;
 
   const updateCellSize = useCallback(() => {
     const availableWidth = window.innerWidth - 40;
@@ -161,7 +164,7 @@ export default function Life() {
         })
       );
     });
-    setTimeout(runSimulation, 500);
+    setTimeout(runSimulation, intervalRef.current);
   }, []);
 
   return (
@@ -195,6 +198,23 @@ export default function Life() {
         >
           Randomize
         </button>
+      </div>
+      <div className="mb-4 flex items-center space-x-2">
+        <label htmlFor="speed" className="text-sm">
+          Speed
+        </label>
+        <input
+          id="speed"
+          type="range"
+          min="100"
+          max="1000"
+          step="100"
+          value={interval}
+          onChange={(e) => setIntervalValue(Number(e.target.value))}
+          className="w-40"
+          style={{ direction: 'rtl' }}
+        />
+        <span className="text-sm">{interval}ms</span>
       </div>
       <div className="mb-4 flex items-center space-x-4">
         <select


### PR DESCRIPTION
## Summary
- allow users to control Game of Life update interval with a slider
## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9b7d7b848326a1dd96e152a16ab7