### PR TITLE
feat: animate cell birth and death

### DIFF
--- a/src/pages/Life.jsx
+++ b/src/pages/Life.jsx
@@ -347,8 +347,9 @@ export default function Life() {
                     ? '#6b21a8'
                     : '#000'
                   : darkMode
-                    ? undefined
+                    ? 'transparent'
                     : '#fff',
+                transition: `background-color ${interval}ms linear`,
               }}
             />
           ))


### PR DESCRIPTION
## Summary
- add background-color transition to Life cells so births and deaths fade at the chosen speed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5d1eff9483268ebb055136d4b724