### PR TITLE
Move toast notifications to top-right for visibility

### DIFF
--- a/src/pages/BrainRotaas.jsx
+++ b/src/pages/BrainRotaas.jsx
@@ -256,7 +256,7 @@ export default function BrainRotaas() {
           </>
         )}
         {toast && (
-          <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded shadow-lg">
+          <div className="fixed top-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-lg">
             {toast}
           </div>
         )}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -48,12 +48,12 @@ export default function Home() {
           </button>
         </form>
         {loading && (
-          <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2">
+          <div className="fixed top-4 right-4">
             <div className="w-8 h-8 border-4 border-purple-400 border-t-transparent border-solid rounded-full animate-spin"></div>
           </div>
         )}
         {!loading && toast && (
-          <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded shadow-lg">
+          <div className="fixed top-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-lg">
             {toast}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Repositioned Home page contact form spinner and toast to the top-right so feedback is visible on all devices.
- Updated BrainRotaas toast notifications to match the new top-right placement.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab62058fe88326a42a788635243223