### PR TITLE
feat: add responsive navbar with hamburger menu

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,27 +1,62 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+const links = [
+  { to: '/', label: 'Home' },
+  { to: '/brainrotaas', label: 'BrainROTAaS' },
+  { to: '/shi-spot', label: 'Shi Spot' },
+  { to: '/gaslight', label: 'GaslightGPT' },
+  { to: '/unspeakable', label: 'Unspeakable' },
+  { to: '/life', label: 'Game of Life' },
+];
+
 export default function Navbar() {
+  const [open, setOpen] = useState(false);
+
+  const renderLinks = () =>
+    links.map((link) => (
+      <li key={link.to}>
+        <Link
+          to={link.to}
+          className="hover:underline"
+          onClick={() => setOpen(false)}
+        >
+          {link.label}
+        </Link>
+      </li>
+    ));
+
   return (
     <nav className="bg-gray-900 text-white px-4 py-3 shadow-md">
-      <ul className="flex flex-wrap gap-4 justify-center">
-        <li>
-          <Link to="/" className="hover:underline">Home</Link>
-        </li>
-        <li>
-          <Link to="/brainrotaas" className="hover:underline">BrainROTAaS</Link>
-        </li>
-        <li>
-          <Link to="/shi-spot" className="hover:underline">Shi Spot</Link>
-        </li>
-        <li>
-          <Link to="/gaslight" className="hover:underline">GaslightGPT</Link>
-        </li>
-        <li>
-          <Link to="/unspeakable" className="hover:underline">Unspeakable</Link>
-        </li>
-        <li>
-          <Link to="/life" className="hover:underline">Game of Life</Link>
-        </li>
+      <div className="flex items-center justify-between md:justify-center">
+        <button
+          className="md:hidden"
+          onClick={() => setOpen(!open)}
+          aria-label="Toggle navigation"
+        >
+          <svg
+            className="h-6 w-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          </svg>
+        </button>
+
+        <ul className="hidden md:flex gap-4">{renderLinks()}</ul>
+      </div>
+
+      <ul
+        className={`${open ? 'flex' : 'hidden'} flex-col gap-2 mt-2 md:hidden`}
+      >
+        {renderLinks()}
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary
- collapse navigation into hamburger menu on small screens
- toggle dropdown links for mobile-first navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab695938e88326ac0a346f5b4deee3