### PR TITLE
Ensure toast placement and route-based titles

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>lkw.lol - Not Found</title>
+    <title>lkw.lol</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
 import Home from './pages/Home.jsx';
 import BrainRotaas from './pages/BrainRotaas.jsx';
 import ShiSpot from './pages/ShiSpot.jsx';
@@ -6,9 +7,27 @@ import GaslightGPT from './pages/GaslightGPT.jsx';
 import Navbar from './components/Navbar.jsx';
 import Life from './pages/Life.jsx';
 
+function TitleUpdater() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const titles = {
+      '/': 'lkw.lol',
+      '/brainrotaas': 'lkw.lol - BrainRotaas',
+      '/shi-spot': 'lkw.lol - Shi Spot',
+      '/gaslight': 'lkw.lol - GaslightGPT',
+      '/life': 'lkw.lol - Life',
+    };
+    document.title = titles[location.pathname] || 'lkw.lol';
+  }, [location.pathname]);
+
+  return null;
+}
+
 export default function App() {
   return (
     <BrowserRouter>
+      <TitleUpdater />
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -35,6 +35,11 @@ export default function Home() {
         </h1>
         <p className="text-xl">Enter at your own peril.</p>
         <form onSubmit={handleSubmit} className="space-y-4">
+          {!loading && toast && (
+            <div className="bg-gray-800 text-white px-4 py-2 rounded shadow-lg">
+              {toast}
+            </div>
+          )}
           <textarea
             className="w-full p-3 rounded-md text-gray-900" rows="4" placeholder="ugh...WHAT??"
             value={message} onChange={(e) => setMessage(e.target.value)}
@@ -50,11 +55,6 @@ export default function Home() {
         {loading && (
           <div className="fixed top-4 right-4">
             <div className="w-8 h-8 border-4 border-purple-400 border-t-transparent border-solid rounded-full animate-spin"></div>
-          </div>
-        )}
-        {!loading && toast && (
-          <div className="fixed top-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-lg">
-            {toast}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Move toast on home page to sit above the textarea
- Dynamically update document titles based on current route and remove misleading 404 title

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6b7f62c88326906f83954f18e5f9