### PR TITLE
feat: add ELI5TEM page

### DIFF
--- a/api/eli5tem.js
+++ b/api/eli5tem.js
@@ -1,0 +1,74 @@
+const fallback = {
+  subject: 'Quantum Entanglement',
+  complex:
+    'Quantum entanglement describes a non-classical correlation between particles where their quantum states become interdependent, so measuring one instantaneously influences the state of the other regardless of spatial separation, challenging local realism and underpinning phenomena like quantum teleportation.',
+  simple:
+    "It's like two magic coins that always show the same side even when they're far apart.",
+};
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(fallback));
+    return;
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content:
+              'Pick an extremely complex STEM subject and explain it. Respond with JSON containing the fields "subject", "complex", and "simple" where "complex" is one technical paragraph and "simple" is the same idea explained in one sentence for a five-year-old.',
+          },
+        ],
+        max_tokens: 200,
+        temperature: 1,
+      }),
+    });
+
+    if (!response.ok) throw new Error('Bad response');
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content;
+
+    let result = fallback;
+    if (content) {
+      const start = content.indexOf('{');
+      const end = content.lastIndexOf('}');
+      if (start !== -1 && end !== -1) {
+        try {
+          const parsed = JSON.parse(content.slice(start, end + 1));
+          if (parsed.subject && parsed.complex && parsed.simple) {
+            result = parsed;
+          }
+        } catch (e) {
+          console.error('JSON parse error', e);
+        }
+      }
+    }
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(result));
+  } catch (err) {
+    console.error(err);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(fallback));
+  }
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import ShiSpot from './pages/ShiSpot.jsx';
 import GaslightGPT from './pages/GaslightGPT.jsx';
 import Navbar from './components/Navbar.jsx';
 import Life from './pages/Life.jsx';
+import ELI5TEM from './pages/ELI5TEM.jsx';
 
 function TitleUpdater() {
   const location = useLocation();
@@ -17,6 +18,7 @@ function TitleUpdater() {
       '/shi-spot': 'lkw.lol - Shi Spot',
       '/gaslight': 'lkw.lol - GaslightGPT',
       '/life': 'lkw.lol - Life',
+      '/ELI5TEM': 'lkw.lol - ELI5TEM',
     };
     document.title = titles[location.pathname] || 'lkw.lol';
   }, [location.pathname]);
@@ -35,6 +37,7 @@ export default function App() {
         <Route path="/shi-spot" element={<ShiSpot />} />
         <Route path="/gaslight" element={<GaslightGPT />} />
         <Route path="/life" element={<Life />} />
+        <Route path="/ELI5TEM" element={<ELI5TEM />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -7,6 +7,7 @@ const links = [
   { to: '/shi-spot', label: 'Shi Spot' },
   { to: '/gaslight', label: 'GaslightGPT' },
   { to: '/life', label: 'Game of Life' },
+  { to: '/ELI5TEM', label: 'ELI5TEM' },
 ];
 
 export default function Navbar() {

--- a/src/pages/ELI5TEM.jsx
+++ b/src/pages/ELI5TEM.jsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+export default function ELI5TEM() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const res = await fetch('/api/eli5tem');
+        if (!res.ok) throw new Error('Bad response');
+        const json = await res.json();
+        setData(json);
+      } catch (err) {
+        console.error(err);
+        setError('Failed to load.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <div className="max-w-2xl text-center space-y-4">
+        <h1 className="text-3xl font-bold">ELI5TEM</h1>
+        {loading && <p>Asking the robots...</p>}
+        {error && <p className="text-red-500">{error}</p>}
+        {data && (
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold">{data.subject}</h2>
+            <p>{data.complex}</p>
+            <p className="font-semibold">{data.simple}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ELI5TEM page that calls OpenAI to explain complex STEM topics with an ELI5 follow-up
- expose API endpoint and route
- update navbar and titles

## Testing
- `npm test` (missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abcb9680248326b31bec83e4d5458f