### PR TITLE
feat: add regenerate to eli5

### DIFF
--- a/api/eli5tem.js
+++ b/api/eli5tem.js
@@ -1,10 +1,37 @@
-const fallback = {
-  subject: 'Quantum Entanglement',
-  complex:
-    'Quantum entanglement describes a non-classical correlation between particles where their quantum states become interdependent, so measuring one instantaneously influences the state of the other regardless of spatial separation, challenging local realism and underpinning phenomena like quantum teleportation.',
-  simple:
-    "It's like two magic coins that always show the same side even when they're far apart.",
-};
+const fallbacks = [
+  {
+    subject: 'Quantum Entanglement',
+    complex:
+      'Quantum entanglement describes a non-classical correlation between particles where their quantum states become interdependent, so measuring one instantaneously influences the state of the other regardless of spatial separation, challenging local realism and underpinning phenomena like quantum teleportation.',
+    simple:
+      "It's like two magic coins that always show the same side even when they're far apart.",
+  },
+  {
+    subject: 'CRISPR-Cas9 Gene Editing',
+    complex:
+      'CRISPR-Cas9 is a molecular complex that can be programmed with guide RNA to locate specific DNA sequences and create double-strand breaks, enabling precise genome modifications for research, medicine, and biotechnology.',
+    simple:
+      'It works like tiny scissors that can cut and paste genes.',
+  },
+  {
+    subject: 'Plate Tectonics',
+    complex:
+      'Plate tectonics theory describes the lithosphere as divided into large plates that float on the semi-fluid asthenosphere, whose interactions at boundaries drive continental drift, mountain building, earthquakes, and volcanism.',
+    simple:
+      "Earth's crust is made of huge pieces that slowly bump into and move away from each other.",
+  },
+  {
+    subject: 'Stellar Nucleosynthesis',
+    complex:
+      'Stellar nucleosynthesis encompasses the nuclear fusion processes within stars that synthesize heavier elements from lighter ones, ultimately dispersing them into the interstellar medium through stellar winds and supernovae.',
+    simple:
+      'Stars make new elements and spread them when they explode.',
+  },
+];
+
+function pickFallback() {
+  return fallbacks[Math.floor(Math.random() * fallbacks.length)];
+}
 
 module.exports = async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -15,6 +42,7 @@ module.exports = async function handler(req, res) {
   }
 
   if (!process.env.OPENAI_API_KEY) {
+    const fallback = pickFallback();
     res.statusCode = 200;
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(fallback));
@@ -34,7 +62,7 @@ module.exports = async function handler(req, res) {
           {
             role: 'user',
             content:
-              'Pick an extremely complex STEM subject and explain it. Respond with JSON containing the fields "subject", "complex", and "simple" where "complex" is one technical paragraph and "simple" is the same idea explained in one sentence for a five-year-old.',
+              'Pick an extremely complex STEM subject from biology, geology, astronomy, physics, chemistry, or mathematics and explain it. Respond with JSON containing the fields "subject", "complex", and "simple" where "complex" is one technical paragraph and "simple" is the same idea explained in one sentence for a five-year-old.',
           },
         ],
         max_tokens: 200,
@@ -46,7 +74,7 @@ module.exports = async function handler(req, res) {
     const data = await response.json();
     const content = data.choices?.[0]?.message?.content;
 
-    let result = fallback;
+    let result = pickFallback();
     if (content) {
       const start = content.indexOf('{');
       const end = content.lastIndexOf('}');
@@ -69,6 +97,6 @@ module.exports = async function handler(req, res) {
     console.error(err);
     res.statusCode = 200;
     res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(fallback));
+    res.end(JSON.stringify(pickFallback()));
   }
 };

--- a/src/pages/ELI5TEM.jsx
+++ b/src/pages/ELI5TEM.jsx
@@ -5,20 +5,23 @@ export default function ELI5TEM() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    async function fetchData() {
-      try {
-        const res = await fetch('/api/eli5tem');
-        if (!res.ok) throw new Error('Bad response');
-        const json = await res.json();
-        setData(json);
-      } catch (err) {
-        console.error(err);
-        setError('Failed to load.');
-      } finally {
-        setLoading(false);
-      }
+  async function fetchData() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/eli5tem');
+      if (!res.ok) throw new Error('Bad response');
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      console.error(err);
+      setError('Failed to load.');
+    } finally {
+      setLoading(false);
     }
+  }
+
+  useEffect(() => {
     fetchData();
   }, []);
 
@@ -35,6 +38,13 @@ export default function ELI5TEM() {
             <p className="font-semibold">{data.simple}</p>
           </div>
         )}
+        <button
+          onClick={fetchData}
+          disabled={loading}
+          className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+        >
+          Regenerate
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add regenerate button to ELI5 page for fetching a new fact
- broaden ELI5 prompt to cover multiple STEM fields and random fallback topics

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abcd322b9c83269677ac5c4b488119