### PR TITLE
Add AI-powered breaking news generator page

### DIFF
--- a/api/breaking.js
+++ b/api/breaking.js
@@ -1,0 +1,84 @@
+const getRandom = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+function fallbackStory() {
+  const subjects = [
+    'A flock of pigeons',
+    'A rogue AI assistant',
+    'An interdimensional donut',
+    'The mayor',
+    'A group of time-traveling squirrels',
+  ];
+  const actions = [
+    'declared war on',
+    'accidentally merged with',
+    'opened a portal to',
+    'held a press conference about',
+    'traded stocks with',
+  ];
+  const objects = [
+    'the moon',
+    'a haunted sandwich',
+    'its own shadow',
+    'an alternate timeline',
+    'a sentient cloud',
+  ];
+  const twists = [
+    'causing mild discomfort',
+    'leaving experts baffled',
+    'triggering a spontaneous disco',
+    'requiring citizens to wear tin-foil hats',
+    'summoning confused philosophers',
+  ];
+  return `${getRandom(subjects)} ${getRandom(actions)} ${getRandom(objects)}, ${getRandom(twists)}.`;
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ story: fallbackStory() }));
+    return;
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content:
+              'Write a single short paragraph for a breaking news story that is ridiculous, confusing and mixes humour, horror, sci-fi and other genres. Keep it under 80 words.',
+          },
+        ],
+        max_tokens: 150,
+        temperature: 1.2,
+      }),
+    });
+
+    if (!response.ok) throw new Error('Bad response');
+    const data = await response.json();
+    const story = data.choices?.[0]?.message?.content?.trim();
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ story: story || fallbackStory() }));
+  } catch (err) {
+    console.error(err);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ story: fallbackStory() }));
+  }
+};
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import GaslightGPT from './pages/GaslightGPT.jsx';
 import Navbar from './components/Navbar.jsx';
 import Life from './pages/Life.jsx';
 import ELI5TEM from './pages/ELI5TEM.jsx';
+import Breaking from './pages/Breaking.jsx';
 
 function TitleUpdater() {
   const location = useLocation();
@@ -17,6 +18,7 @@ function TitleUpdater() {
       '/brainrotaas': 'lkw.lol - BrainRotaas',
       '/shi-spot': 'lkw.lol - Shi Spot',
       '/gaslight': 'lkw.lol - GaslightGPT',
+      '/breaking': 'lkw.lol - Breaking News',
       '/life': 'lkw.lol - Life',
       '/ELI5TEM': 'lkw.lol - ELI5TEM',
     };
@@ -36,6 +38,7 @@ export default function App() {
         <Route path="/brainrotaas" element={<BrainRotaas />} />
         <Route path="/shi-spot" element={<ShiSpot />} />
         <Route path="/gaslight" element={<GaslightGPT />} />
+        <Route path="/breaking" element={<Breaking />} />
         <Route path="/life" element={<Life />} />
         <Route path="/ELI5TEM" element={<ELI5TEM />} />
       </Routes>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -6,6 +6,7 @@ const links = [
   { to: '/brainrotaas', label: 'BrainROTAaS' },
   { to: '/shi-spot', label: 'Shi Spot' },
   { to: '/gaslight', label: 'GaslightGPT' },
+  { to: '/breaking', label: 'Breaking News' },
   { to: '/life', label: 'Game of Life' },
   { to: '/ELI5TEM', label: 'ELI5TEM' },
 ];

--- a/src/pages/Breaking.jsx
+++ b/src/pages/Breaking.jsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+
+export default function Breaking() {
+  const [story, setStory] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const fetchStory = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/breaking');
+      const data = await res.json();
+      setStory(data.story || 'The news feed malfunctioned.');
+    } catch (err) {
+      console.error(err);
+      setStory('The news feed malfunctioned.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStory();
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-black text-white text-center p-4 space-y-6">
+      <h1 className="text-3xl font-bold">Breaking News</h1>
+      <p className="max-w-2xl">{loading ? 'Transmitting…' : story}</p>
+      <button
+        onClick={fetchStory}
+        className="mt-4 px-4 py-2 bg-gray-800 hover:bg-gray-700 rounded flex items-center gap-2"
+      >
+        <span>next story</span>
+        <span aria-hidden>→</span>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/breaking` page that fetches a wildly surreal news story from a new OpenAI-powered API
- provide fallback story generator for when no OpenAI key is present
- expose page in router and navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abddc5e4ac8326af64c425dd4f2cec