### PR TITLE
fix: prevent sign-in button form submission

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,7 @@ export default function App() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <button
+          type="button"
           onClick={signIn}
           className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500"
         >


### PR DESCRIPTION
## Summary
- add explicit `type="button"` to Google sign-in button so it doesn't submit forms and reload

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad00e6c0f88326b6bc6979c2294592