### PR TITLE
feat: add shape-switchable Game of Life

### DIFF
--- a/src/components/life/HexGrid.jsx
+++ b/src/components/life/HexGrid.jsx
@@ -1,0 +1,40 @@
+const sqrt3 = Math.sqrt(3);
+
+export default function HexGrid({ grid, cellSize, toggle }) {
+  const cols = grid[0].length;
+  const rows = grid.length;
+  const w = cellSize;
+  const h = (sqrt3 / 2) * w;
+  const svgWidth = w + (cols - 1) * (w * 0.75);
+  const svgHeight = rows * h + h / 2;
+
+  return (
+    <svg width={svgWidth} height={svgHeight}>
+      {grid.map((row, i) =>
+        row.map((cell, j) => {
+          const x = j * (w * 0.75);
+          const y = i * h + (j % 2 ? h / 2 : 0);
+          const points = [
+            [x + w / 2, y],
+            [x + w, y + h / 2],
+            [x + w, y + h],
+            [x + w / 2, y + h + h / 2],
+            [x, y + h],
+            [x, y + h / 2],
+          ]
+            .map((p) => p.join(','))
+            .join(' ');
+          return (
+            <polygon
+              key={`${i}-${j}`}
+              points={points}
+              fill={cell ? '#000' : '#fff'}
+              stroke="#888"
+              onClick={() => toggle(i, j)}
+            />
+          );
+        })
+      )}
+    </svg>
+  );
+}

--- a/src/components/life/LifeControls.jsx
+++ b/src/components/life/LifeControls.jsx
@@ -1,0 +1,67 @@
+export default function LifeControls({
+  shape,
+  setShape,
+  triMode,
+  setTriMode,
+  wrap,
+  setWrap,
+  speed,
+  setSpeed,
+  running,
+  start,
+  stop,
+  step,
+  randomize,
+  clear,
+  ruleText,
+}) {
+  return (
+    <div className="flex flex-col gap-2 items-center">
+      <div className="flex items-center gap-2">
+        <span className="text-sm">Cell Shape</span>
+        <div className="flex">
+          {[3,4,6].map(s => (
+            <button
+              key={s}
+              className={`px-2 py-1 border ${shape===s?'bg-purple-600 text-white':'bg-gray-200'}`}
+              onClick={() => setShape(s)}
+            >
+              {s===3?'Triangle':s===4?'Square':'Hexagon'}
+            </button>
+          ))}
+        </div>
+      </div>
+      {shape===3 && (
+        <label className="flex items-center gap-1 text-sm">
+          <input type="checkbox" checked={triMode} onChange={e=>setTriMode(e.target.checked)} />
+          Include vertex neighbors
+        </label>
+      )}
+      <label className="flex items-center gap-1 text-sm">
+        <input type="checkbox" checked={wrap} onChange={e=>setWrap(e.target.checked)} />
+        Wrap
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        Speed
+        <input
+          type="range"
+          min="50"
+          max="1000"
+          step="50"
+          value={speed}
+          onChange={e=>setSpeed(Number(e.target.value))}
+        />
+        <span>{speed}ms</span>
+      </label>
+      <div className="flex gap-2 mt-2">
+        <button className="px-2 py-1 bg-purple-600 text-white" onClick={running?stop:start}>
+          {running?'Stop':'Start'}
+        </button>
+        <button className="px-2 py-1 bg-gray-300" onClick={step}>Step</button>
+        <button className="px-2 py-1 bg-green-600 text-white" onClick={randomize}>Randomize</button>
+        <button className="px-2 py-1 bg-red-600 text-white" onClick={clear}>Clear</button>
+      </div>
+      <div className="text-sm mt-2">Rule: {ruleText}</div>
+    </div>
+  );
+}

--- a/src/components/life/SquareGrid.jsx
+++ b/src/components/life/SquareGrid.jsx
@@ -1,0 +1,23 @@
+export default function SquareGrid({ grid, cellSize, toggle }) {
+  return (
+    <div
+      className="grid"
+      style={{ gridTemplateColumns: `repeat(${grid[0].length}, ${cellSize}px)` }}
+    >
+      {grid.map((row, i) =>
+        row.map((cell, j) => (
+          <div
+            key={`${i}-${j}`}
+            onClick={() => toggle(i, j)}
+            className="border border-gray-400"
+            style={{
+              width: cellSize,
+              height: cellSize,
+              background: cell ? '#000' : '#fff',
+            }}
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/components/life/TriGrid.jsx
+++ b/src/components/life/TriGrid.jsx
@@ -1,0 +1,34 @@
+const sqrt3 = Math.sqrt(3);
+
+export default function TriGrid({ grid, cellSize, toggle }) {
+  const cols = grid[0].length;
+  const rows = grid.length;
+  const width = cellSize;
+  const height = (cellSize * sqrt3) / 2;
+  const svgWidth = (cols + 1) * width / 2;
+  const svgHeight = rows * height;
+
+  return (
+    <svg width={svgWidth} height={svgHeight}>
+      {grid.map((row, i) =>
+        row.map((cell, j) => {
+          const x = j * width / 2;
+          const y = i * height;
+          const up = (i + j) % 2 === 0;
+          const points = up
+            ? `${x},${y + height} ${x + width / 2},${y} ${x + width},${y + height}`
+            : `${x},${y} ${x + width / 2},${y + height} ${x + width},${y}`;
+          return (
+            <polygon
+              key={`${i}-${j}`}
+              points={points}
+              fill={cell ? '#000' : '#fff'}
+              stroke="#888"
+              onClick={() => toggle(i, j)}
+            />
+          );
+        })
+      )}
+    </svg>
+  );
+}

--- a/src/hooks/useLife.js
+++ b/src/hooks/useLife.js
@@ -1,0 +1,56 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+export function useLife(rows, cols, neighborFn, birthSet, surviveSet, wrap, speed) {
+  const generateEmpty = useCallback(() => Array.from({length: rows}, () => Array(cols).fill(0)), [rows, cols]);
+  const [grid, setGrid] = useState(() => generateEmpty());
+  const [running, setRunning] = useState(false);
+  const speedRef = useRef(speed);
+  const runningRef = useRef(running);
+  const timeoutRef = useRef();
+
+  useEffect(() => { speedRef.current = speed; }, [speed]);
+  useEffect(() => { runningRef.current = running; }, [running]);
+
+  const step = useCallback(() => {
+    setGrid(g => {
+      const newGrid = g.map((row,i) => row.map((cell,j) => {
+        const n = neighborFn(g,i,j,wrap);
+        if (cell) return surviveSet.includes(n) ? 1 : 0;
+        return birthSet.includes(n) ? 1 : 0;
+      }));
+      return newGrid;
+    });
+  }, [neighborFn, surviveSet, birthSet, wrap]);
+
+  const run = useCallback(() => {
+    if (!runningRef.current) return;
+    step();
+    timeoutRef.current = setTimeout(run, speedRef.current);
+  }, [step]);
+
+  const start = useCallback(() => {
+    if (!runningRef.current) {
+      setRunning(true);
+      runningRef.current = true;
+      run();
+    }
+  }, [run]);
+
+  const stop = useCallback(() => {
+    setRunning(false);
+    runningRef.current = false;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
+
+  const randomize = useCallback(() => {
+    setGrid(() => Array.from({length: rows}, () => Array.from({length: cols}, () => Math.random() < 0.33 ? 1 : 0)));
+  }, [rows, cols]);
+
+  const clear = useCallback(() => {
+    setGrid(generateEmpty());
+  }, [generateEmpty]);
+
+  useEffect(() => () => { if(timeoutRef.current) clearTimeout(timeoutRef.current); }, []);
+
+  return { grid, setGrid, running, start, stop, step, randomize, clear };
+}

--- a/src/lib/rules.js
+++ b/src/lib/rules.js
@@ -1,0 +1,101 @@
+export function computeRuleSets(N) {
+  const birth = Math.round(0.375 * N);
+  const surviveMin = Math.ceil(0.25 * N);
+  const surviveMax = Math.round(0.375 * N);
+  const surviveSet = [];
+  for (let k = surviveMin; k <= surviveMax; k++) {
+    surviveSet.push(k);
+  }
+  const birthSet = [birth];
+  const ruleText = `B${birthSet.join(',')}/S${surviveSet.join('-')}`;
+  return { birthSet, surviveSet, ruleText };
+}
+
+export function squareNeighbors(grid, i, j, wrap) {
+  const deltas = [
+    [0, 1],[0, -1],[1, 0],[-1, 0],[1, 1],[1, -1],[-1, 1],[-1, -1],
+  ];
+  const rows = grid.length;
+  const cols = grid[0].length;
+  let count = 0;
+  for (const [dx, dy] of deltas) {
+    let x = i + dx;
+    let y = j + dy;
+    if (wrap) {
+      x = (x + rows) % rows;
+      y = (y + cols) % cols;
+    }
+    if (x >= 0 && x < rows && y >= 0 && y < cols) {
+      count += grid[x][y];
+    }
+  }
+  return count;
+}
+
+export function hexNeighbors(grid, i, j, wrap) {
+  const rows = grid.length;
+  const cols = grid[0].length;
+  const even = j % 2 === 0;
+  const deltas = even
+    ? [[-1,0],[1,0],[0,-1],[0,1],[-1,-1],[-1,1]]
+    : [[-1,0],[1,0],[0,-1],[0,1],[1,-1],[1,1]];
+  let count = 0;
+  for (const [dx, dy] of deltas) {
+    let x = i + dx;
+    let y = j + dy;
+    if (wrap) {
+      x = (x + rows) % rows;
+      y = (y + cols) % cols;
+    }
+    if (x >= 0 && x < rows && y >= 0 && y < cols) {
+      count += grid[x][y];
+    }
+  }
+  return count;
+}
+
+export function triNeighbors(grid, i, j, includeVertices, wrap) {
+  const rows = grid.length;
+  const cols = grid[0].length;
+  const up = (i + j) % 2 === 0;
+  let deltas;
+  if (!includeVertices) {
+    deltas = up ? [[0,-1],[0,1],[-1,0]] : [[0,-1],[0,1],[1,0]];
+  } else {
+    if (up) {
+      deltas = [
+        [0,-1],[0,1],[-1,0],
+        [-1,-1],[0,-2],[1,-1],
+        [-1,1],[0,2],[1,1],
+        [-2,0],[-1,-2],[-1,2],
+      ];
+    } else {
+      deltas = [
+        [0,-1],[0,1],[1,0],
+        [1,-1],[0,-2],[-1,-1],
+        [1,1],[0,2],[-1,1],
+        [2,0],[1,-2],[1,2],
+      ];
+    }
+  }
+  let count = 0;
+  for (const [dx, dy] of deltas) {
+    let x = i + dx;
+    let y = j + dy;
+    if (wrap) {
+      x = (x + rows) % rows;
+      y = (y + cols) % cols;
+    }
+    if (x >= 0 && x < rows && y >= 0 && y < cols) {
+      count += grid[x][y];
+    }
+  }
+  return count;
+}
+
+export function getNeighborFunction(shape, triMode) {
+  if (shape === 4) return { N:8, fn: squareNeighbors };
+  if (shape === 6) return { N:6, fn: hexNeighbors };
+  if (shape === 3 && triMode) return { N:12, fn: (g,i,j,w)=>triNeighbors(g,i,j,true,w) };
+  return { N:3, fn: (g,i,j,w)=>triNeighbors(g,i,j,false,w) };
+}


### PR DESCRIPTION
## Summary
- add reusable rules utilities and neighbor functions for square, hex, and triangle lattices
- implement modular Game of Life with cell shape selector, wrap and speed controls, and rule text
- render grids for square, hexagon, and triangle cells with toggleable vertex neighbors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad284f45e48326a6b41a0fc3fee0ad