### PR TITLE
feat: add square shape picker and tweak triangle randomness

### DIFF
--- a/src/components/life/SquareGrid.jsx
+++ b/src/components/life/SquareGrid.jsx
@@ -1,4 +1,4 @@
-export default function SquareGrid({ grid, cellSize, toggle }) {
+export default function SquareGrid({ grid, cellSize, toggle, insertShapeAt }) {
   return (
     <div
       className="grid"
@@ -9,6 +9,11 @@ export default function SquareGrid({ grid, cellSize, toggle }) {
           <div
             key={`${i}-${j}`}
             onClick={() => toggle(i, j)}
+            onDragOver={e => e.preventDefault()}
+            onDrop={e => {
+              const shape = e.dataTransfer.getData('shape');
+              if (shape && insertShapeAt) insertShapeAt(shape, i, j);
+            }}
             className="border border-gray-400"
             style={{
               width: cellSize,

--- a/src/components/life/SquareSetup.jsx
+++ b/src/components/life/SquareSetup.jsx
@@ -1,0 +1,68 @@
+import { shapePatterns, shapes } from '../../lib/squareShapes';
+
+export default function SquareSetup({ selectedShape, setSelectedShape }) {
+  return (
+    <div className="mb-4 flex items-center space-x-4">
+      <select
+        value={selectedShape}
+        onChange={e => setSelectedShape(e.target.value)}
+        className="bg-gray-700 text-white p-2 rounded"
+      >
+        <optgroup label="Still Lifes">
+          <option value="block">Block</option>
+          <option value="beehive">Beehive</option>
+          <option value="loaf">Loaf</option>
+          <option value="boat">Boat</option>
+          <option value="tub">Tub</option>
+        </optgroup>
+        <optgroup label="Oscillators">
+          <option value="blinker">Blinker (period 2)</option>
+          <option value="toad">Toad (period 2)</option>
+          <option value="beacon">Beacon (period 2)</option>
+          <option value="pulsar">Pulsar (period 3)</option>
+          <option value="penta-decathlon">Penta-decathlon (period 15)</option>
+        </optgroup>
+        <optgroup label="Spaceships">
+          <option value="glider">Glider</option>
+          <option value="lwss">Light-weight spaceship (LWSS)</option>
+          <option value="mwss">Middleweight spaceship (MWSS)</option>
+          <option value="hwss">Heavy-weight spaceship (HWSS)</option>
+        </optgroup>
+      </select>
+      {selectedShape && (
+        <div
+          draggable
+          onDragStart={e => e.dataTransfer.setData('shape', selectedShape)}
+          className="inline-block"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${shapePatterns[selectedShape][0].length}, 15px)`,
+          }}
+        >
+          {(() => {
+            const coords = new Set(
+              shapes[selectedShape].map(([r, c]) => `${r}-${c}`)
+            );
+            const rows = shapePatterns[selectedShape].length;
+            const cols = shapePatterns[selectedShape][0].length;
+            return Array.from({ length: rows }).flatMap((_, r) =>
+              Array.from({ length: cols }).map((_, c) => (
+                <div
+                  key={`${r}-${c}`}
+                  className="border border-gray-700"
+                  style={{
+                    width: 15,
+                    height: 15,
+                    backgroundColor: coords.has(`${r}-${c}`)
+                      ? '#6b21a8'
+                      : undefined,
+                  }}
+                />
+              ))
+            );
+          })()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/squareShapes.js
+++ b/src/lib/squareShapes.js
@@ -1,0 +1,57 @@
+const shapePatterns = {
+  block: ["OO", "OO"],
+  beehive: [".OO.", "O..O", ".OO."],
+  loaf: [".OO.", "O..O", ".O.O", "..O."],
+  boat: ["OO.", "O.O", ".O."],
+  tub: [".O.", "O.O", ".O."],
+  blinker: ["OOO"],
+  toad: [".OOO", "OOO."],
+  beacon: ["OO..", "OO..", "..OO", "..OO"],
+  pulsar: [
+    "..OOO...OOO..",
+    ".............",
+    "O....O.O....O",
+    "O....O.O....O",
+    "O....O.O....O",
+    "..OOO...OOO..",
+    ".............",
+    "..OOO...OOO..",
+    "O....O.O....O",
+    "O....O.O....O",
+    "O....O.O....O",
+    ".............",
+    "..OOO...OOO..",
+  ],
+  "penta-decathlon": [
+    ".O.",
+    "OOO",
+    ".O.",
+    ".O.",
+    ".O.",
+    ".O.",
+    ".O.",
+    ".O.",
+    "OOO",
+    ".O.",
+  ],
+  glider: [".O.", "..O", "OOO"],
+  lwss: [".O..O", "O....", "O...O", "OOOO."],
+  mwss: ["..O..O", "O.....", "O....O", "OOOOO.", ".O..O."],
+  hwss: ["..O...O", "O......", "O.....O", "OOOOOO.", ".OO..O."],
+};
+
+const patternToCoords = (pattern) => {
+  const coords = [];
+  pattern.forEach((row, r) => {
+    row.split('').forEach((cell, c) => {
+      if (cell === 'O') coords.push([r, c]);
+    });
+  });
+  return coords;
+};
+
+const shapes = Object.fromEntries(
+  Object.entries(shapePatterns).map(([name, pattern]) => [name, patternToCoords(pattern)])
+);
+
+export { shapePatterns, shapes };

--- a/src/pages/Life.jsx
+++ b/src/pages/Life.jsx
@@ -3,8 +3,10 @@ import LifeControls from '../components/life/LifeControls';
 import SquareGrid from '../components/life/SquareGrid';
 import HexGrid from '../components/life/HexGrid';
 import TriGrid from '../components/life/TriGrid';
+import SquareSetup from '../components/life/SquareSetup';
 import { computeRuleSets, getNeighborFunction } from '../lib/rules';
 import { useLife } from '../hooks/useLife';
+import { shapes } from '../lib/squareShapes';
 
 const ROWS = 20;
 const COLS = 20;
@@ -15,6 +17,7 @@ export default function Life() {
   const [triMode, setTriMode] = useState(() => localStorage.getItem('life_tri') === '1');
   const [wrap, setWrap] = useState(() => localStorage.getItem('life_wrap') !== '0');
   const [speed, setSpeed] = useState(() => Number(localStorage.getItem('life_speed')) || 500);
+  const [selectedShape, setSelectedShape] = useState('block');
 
   useEffect(() => { localStorage.setItem('life_shape', String(shape)); }, [shape]);
   useEffect(() => { localStorage.setItem('life_tri', triMode ? '1':'0'); }, [triMode]);
@@ -30,6 +33,33 @@ export default function Life() {
   const toggle = useCallback((i,j) => {
     setGrid(g => g.map((row,ri) => row.map((cell,ci) => (ri===i && ci===j) ? (cell?0:1) : cell)));
   }, [setGrid]);
+
+  const insertShapeAt = useCallback((shapeName, x, y) => {
+    const shapeCells = shapes[shapeName];
+    setGrid(g => {
+      const newGrid = g.map(row => [...row]);
+      shapeCells.forEach(([dx, dy]) => {
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= 0 && nx < ROWS && ny >= 0 && ny < COLS) {
+          newGrid[nx][ny] = 1;
+        }
+      });
+      return newGrid;
+    });
+  }, [setGrid]);
+
+  const randomizeGrid = useCallback(() => {
+    if (shape === 3) {
+      setGrid(() =>
+        Array.from({ length: ROWS }, () =>
+          Array.from({ length: COLS }, () => (Math.random() < 0.15 ? 1 : 0))
+        )
+      );
+    } else {
+      randomize();
+    }
+  }, [shape, setGrid, randomize]);
 
   let GridComp = SquareGrid;
   if (shape === 3) GridComp = TriGrid;
@@ -50,11 +80,18 @@ export default function Life() {
         start={start}
         stop={stop}
         step={step}
-        randomize={randomize}
+        randomize={randomizeGrid}
         clear={clear}
         ruleText={ruleText}
       />
-      <GridComp grid={grid} cellSize={CELL} toggle={toggle} />
+      {shape===4 && (
+        <SquareSetup selectedShape={selectedShape} setSelectedShape={setSelectedShape} />
+      )}
+      {(() => {
+        const props = { grid, cellSize: CELL, toggle };
+        if (shape === 4) props.insertShapeAt = insertShapeAt;
+        return <GridComp {...props} />;
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Reduce triangle grid randomization density to keep initial activation manageable
- Reintroduce square pattern selection with draggable previews and pattern data
- Allow dropping selected square patterns onto the grid for custom setups

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2c042b7c8326bb8addeef722bbfa