### PR TITLE
Swap tic tac toe for math quiz gate

### DIFF
--- a/api/math-quiz.js
+++ b/api/math-quiz.js
@@ -1,0 +1,105 @@
+const getRandom = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+const fallbackQuiz = () => {
+  const quizzes = [
+    {
+      question: 'Solve for x: 2x + 3 = 11',
+      choices: ['3', '4', '5', '6'],
+      answer: 1,
+    },
+    {
+      question: 'What is the value of x in 3x - 5 = 16?',
+      choices: ['5', '7', '8', '11'],
+      answer: 2,
+    },
+    {
+      question: 'If x^2 = 49, what is x?',
+      choices: ['-7 or 7', '7', '-7', '0'],
+      answer: 0,
+    },
+    {
+      question: 'Simplify: (x^2 - 9) / (x - 3) when x = 5',
+      choices: ['7', '8', '9', '10'],
+      answer: 2,
+    },
+  ];
+  return getRandom(quizzes);
+};
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.statusCode = 405;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    return;
+  }
+
+  const sendQuiz = (quiz) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(quiz));
+  };
+
+  if (!process.env.OPENAI_API_KEY) {
+    sendQuiz(fallbackQuiz());
+    return;
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content:
+              'Provide one moderately difficult algebra question with exactly four possible answers. ' +
+              'Return ONLY valid JSON with the fields: question (string), choices (array of four strings), and answer (number index of correct choice).',
+          },
+        ],
+        max_tokens: 200,
+        temperature: 0.7,
+      }),
+    });
+
+    if (!response.ok) throw new Error('Bad response');
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content;
+    let quiz;
+    if (content) {
+      try {
+        const jsonStart = content.indexOf('{');
+        const jsonEnd = content.lastIndexOf('}');
+        if (jsonStart !== -1 && jsonEnd !== -1) {
+          const jsonString = content.slice(jsonStart, jsonEnd + 1);
+          quiz = JSON.parse(jsonString);
+        }
+      } catch (err) {
+        quiz = null;
+      }
+    }
+
+    if (
+      !quiz ||
+      !quiz.question ||
+      !Array.isArray(quiz.choices) ||
+      quiz.choices.length !== 4 ||
+      typeof quiz.answer !== 'number' ||
+      quiz.answer < 0 ||
+      quiz.answer > 3
+    ) {
+      quiz = fallbackQuiz();
+    }
+
+    sendQuiz(quiz);
+  } catch (err) {
+    console.error(err);
+    sendQuiz(fallbackQuiz());
+  }
+};

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -2,79 +2,48 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 
-const lines = [
-  [0, 1, 2],
-  [3, 4, 5],
-  [6, 7, 8],
-  [0, 3, 6],
-  [1, 4, 7],
-  [2, 5, 8],
-  [0, 4, 8],
-  [2, 4, 6],
-];
-
-function calculateWinner(board) {
-  for (const [a, b, c] of lines) {
-    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
-      return board[a];
-    }
-  }
-  return board.every(Boolean) ? 'draw' : null;
-}
-
 export default function Landing() {
   const { user, signIn } = useAuth();
   const navigate = useNavigate();
-  const [board, setBoard] = useState(Array(9).fill(null));
-  const [isPlayerTurn, setIsPlayerTurn] = useState(true);
-  const [winner, setWinner] = useState(null);
+  const [quiz, setQuiz] = useState(null);
+  const [selected, setSelected] = useState(null);
+  const [correct, setCorrect] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (user) navigate('/contact');
   }, [user, navigate]);
 
-  const handleClick = (idx) => {
-    if (board[idx] || !isPlayerTurn || winner) return;
-    const newBoard = [...board];
-    newBoard[idx] = 'X';
-    setBoard(newBoard);
-    const w = calculateWinner(newBoard);
-    if (w) {
-      setWinner(w);
-    } else {
-      setIsPlayerTurn(false);
-    }
-  };
-
   useEffect(() => {
-    if (!isPlayerTurn && !winner) {
-      const empty = board
-        .map((v, i) => (v ? null : i))
-        .filter((v) => v !== null);
-      if (empty.length === 0) return;
-      const choice = empty[Math.floor(Math.random() * empty.length)];
-      const newBoard = [...board];
-      newBoard[choice] = 'O';
-      setBoard(newBoard);
-      const w = calculateWinner(newBoard);
-      if (w) {
-        setWinner(w);
-      } else {
-        setIsPlayerTurn(true);
+    async function loadQuiz() {
+      try {
+        const res = await fetch('/api/math-quiz');
+        const data = await res.json();
+        if (
+          data &&
+          data.question &&
+          Array.isArray(data.choices) &&
+          data.choices.length === 4 &&
+          typeof data.answer === 'number'
+        ) {
+          setQuiz(data);
+        } else {
+          setError('Failed to load quiz');
+        }
+      } catch (err) {
+        setError('Failed to load quiz');
       }
     }
-  }, [isPlayerTurn, board, winner]);
+    loadQuiz();
+  }, []);
 
-  const reset = () => {
-    setBoard(Array(9).fill(null));
-    setWinner(null);
-    setIsPlayerTurn(true);
+  const handleAnswer = (idx) => {
+    if (!quiz) return;
+    setSelected(idx);
+    if (idx === quiz.answer) {
+      setCorrect(true);
+    }
   };
-
-  let status = '';
-  if (winner === 'X') status = 'You win!';
-  else if (winner === 'O') status = 'You lose!';
-  else if (winner === 'draw') status = "It's a draw!";
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-white space-y-6 p-4">
@@ -82,38 +51,35 @@ export default function Landing() {
         <span className="font-extrabold">LKW</span>
         <span className="font-light">.lol</span>
       </h1>
-      <p className="text-xl">Win a game of Tic Tac Toe to enter.</p>
-      <div className="grid grid-cols-3 gap-2">
-        {board.map((val, idx) => (
-          <button
-            key={idx}
-            onClick={() => handleClick(idx)}
-            className="w-20 h-20 bg-gray-800 flex items-center justify-center text-3xl font-bold"
-          >
-            {val}
-          </button>
-        ))}
-      </div>
-      {status && <div className="text-lg">{status}</div>}
-      {winner === 'X' && !user && (
+      <p className="text-xl">Solve the math problem to enter.</p>
+      {error && <div className="text-red-400">{error}</div>}
+      {quiz ? (
+        <div className="flex flex-col items-center space-y-4">
+          <div className="text-lg text-center max-w-md">{quiz.question}</div>
+          <div className="grid grid-cols-2 gap-4">
+            {quiz.choices.map((choice, idx) => (
+              <button
+                key={idx}
+                onClick={() => handleAnswer(idx)}
+                className="px-4 py-2 bg-gray-800 rounded hover:bg-gray-700"
+              >
+                {choice}
+              </button>
+            ))}
+          </div>
+          {selected !== null && selected !== quiz.answer && (
+            <div className="text-red-400">Incorrect, try again.</div>
+          )}
+        </div>
+      ) : (
+        !error && <div>Loading...</div>
+      )}
+      {correct && !user && (
         <button
           onClick={signIn}
           className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-500"
         >
           Sign in with Google
-        </button>
-      )}
-      {winner && winner !== 'X' && (
-        <button
-          onClick={reset}
-          className="px-4 py-2 bg-purple-600 rounded hover:bg-purple-500"
-        >
-          Try Again
-        </button>
-      )}
-      {!winner && (
-        <button onClick={reset} className="underline">
-          Reset
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Replace tic tac toe gate on landing page with an algebra quiz pulled from OpenAI
- Add `/api/math-quiz` endpoint with fallback to local questions for missing data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade6ef24c48326a4cc715b3ae09512