### PR TITLE
Simplify landing page and protect contact

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,7 +52,10 @@ export default function App() {
       {user && <Navbar />}
       <Routes>
         <Route path="/" element={<Landing />} />
-        <Route path="/contact" element={<Contact />} />
+        <Route
+          path="/contact"
+          element={user ? <Contact /> : <Navigate to="/" replace />}
+        />
         <Route
           path="/brainrotaas"
           element={user ? <BrainRotaas /> : <Navigate to="/" replace />}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -65,6 +65,9 @@ export default function Navbar() {
       >
         {renderLinks()}
         <li>
+          <hr className="my-2 border-gray-700" />
+        </li>
+        <li>
           <button onClick={signOut} className="text-left hover:underline">Sign out</button>
         </li>
       </ul>

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,49 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 
 export default function Landing() {
   const { user, signIn } = useAuth();
   const navigate = useNavigate();
-  const [quiz, setQuiz] = useState(null);
-  const [selected, setSelected] = useState(null);
-  const [correct, setCorrect] = useState(false);
-  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (user) navigate('/contact');
   }, [user, navigate]);
-
-  useEffect(() => {
-    async function loadQuiz() {
-      try {
-        const res = await fetch('/api/math-quiz');
-        const data = await res.json();
-        if (
-          data &&
-          data.question &&
-          Array.isArray(data.choices) &&
-          data.choices.length === 4 &&
-          typeof data.answer === 'number'
-        ) {
-          setQuiz(data);
-        } else {
-          setError('Failed to load quiz');
-        }
-      } catch (err) {
-        setError('Failed to load quiz');
-      }
-    }
-    loadQuiz();
-  }, []);
-
-  const handleAnswer = (idx) => {
-    if (!quiz) return;
-    setSelected(idx);
-    if (idx === quiz.answer) {
-      setCorrect(true);
-    }
-  };
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-900 text-white space-y-6 p-4">
@@ -51,30 +16,8 @@ export default function Landing() {
         <span className="font-extrabold">LKW</span>
         <span className="font-light">.lol</span>
       </h1>
-      <p className="text-xl">Solve the math problem to enter.</p>
-      {error && <div className="text-red-400">{error}</div>}
-      {quiz ? (
-        <div className="flex flex-col items-center space-y-4">
-          <div className="text-lg text-center max-w-md">{quiz.question}</div>
-          <div className="grid grid-cols-2 gap-4">
-            {quiz.choices.map((choice, idx) => (
-              <button
-                key={idx}
-                onClick={() => handleAnswer(idx)}
-                className="px-4 py-2 bg-gray-800 rounded hover:bg-gray-700"
-              >
-                {choice}
-              </button>
-            ))}
-          </div>
-          {selected !== null && selected !== quiz.answer && (
-            <div className="text-red-400">Incorrect, try again.</div>
-          )}
-        </div>
-      ) : (
-        !error && <div>Loading...</div>
-      )}
-      {correct && !user && (
+      <p className="text-xl">Welcome to the site.</p>
+      {!user && (
         <button
           onClick={signIn}
           className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-500"


### PR DESCRIPTION
## Summary
- Remove math quiz gate in favor of a simple welcome with a sign-in call-to-action.
- Lock down the `/contact` route so only authenticated users can access it.
- Add a horizontal separator above the sign-out option in the mobile dropdown menu.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adec1eaa108326ac3511eb8a731cfe