### PR TITLE
Add pipeline route for CSV inventory upload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ import GaslightGPT from './pages/GaslightGPT.jsx';
 import Navbar from './components/Navbar.jsx';
 import Life from './pages/Life.jsx';
 import Note from './pages/Note.jsx';
+import Pipeline from './pages/Pipeline.jsx';
+import PipelineDetail from './pages/PipelineDetail.jsx';
 import { useAuth } from './context/AuthContext';
 
 function TitleUpdater() {
@@ -28,8 +30,13 @@ function TitleUpdater() {
       '/gaslight': 'lkw.lol - GaslightGPT',
       '/life': 'lkw.lol - Life',
       '/note': 'lkw.lol - Notes',
+      '/pipeline': 'lkw.lol - Pipeline',
     };
-    document.title = titles[location.pathname] || 'lkw.lol';
+    if (location.pathname.startsWith('/pipeline')) {
+      document.title = 'lkw.lol - Pipeline';
+    } else {
+      document.title = titles[location.pathname] || 'lkw.lol';
+    }
   }, [location.pathname]);
 
   return null;
@@ -75,6 +82,14 @@ export default function App() {
         <Route
           path="/note"
           element={user ? <Note /> : <Navigate to="/" replace />}
+        />
+        <Route
+          path="/pipeline"
+          element={user ? <Pipeline /> : <Navigate to="/" replace />}
+        />
+        <Route
+          path="/pipeline/:stockNumber"
+          element={user ? <PipelineDetail /> : <Navigate to="/" replace />}
         />
       </Routes>
     </BrowserRouter>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -9,6 +9,7 @@ const links = [
   { to: '/gaslight', label: 'GaslightGPT' },
   { to: '/life', label: 'Game of Life' },
   { to: '/note', label: 'Notes' },
+  { to: '/pipeline', label: 'Pipeline' },
 ];
 
 export default function Navbar() {

--- a/src/pages/Pipeline.jsx
+++ b/src/pages/Pipeline.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Pipeline() {
+  const [cars, setCars] = useState([]);
+  const navigate = useNavigate();
+
+  const handleFileUpload = (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const text = event.target?.result;
+      if (typeof text !== 'string') return;
+      const [headerLine, ...lines] = text.trim().split(/\r?\n/);
+      const headers = headerLine.split(',');
+      const data = lines.map((line) => {
+        const values = line.split(',');
+        const obj = {};
+        headers.forEach((h, i) => {
+          obj[h.trim()] = values[i]?.trim();
+        });
+        return obj;
+      });
+      setCars(data);
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Pipeline</h1>
+      <label htmlFor="inventory" className="block mb-2 font-semibold">
+        Upload current inventory
+      </label>
+      <input
+        id="inventory"
+        type="file"
+        accept=".csv"
+        onChange={handleFileUpload}
+        className="mb-4"
+      />
+      <ul className="divide-y">
+        {cars.map((car) => (
+          <li key={car['Stock Number']}>
+            <button
+              type="button"
+              className="w-full flex items-center justify-between p-2 hover:bg-gray-100"
+              onClick={() =>
+                navigate(`/pipeline/${car['Stock Number']}`, { state: { car } })
+              }
+            >
+              <span className="mr-2">🚗</span>
+              <span className="flex-1 text-left">
+                {car['Stock Number']} {car.Year} {car.Make} {car.Model}
+              </span>
+              <span className="mr-4">{car.Odometer} mi</span>
+              <span>{car['Days In Stock']} days</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/PipelineDetail.jsx
+++ b/src/pages/PipelineDetail.jsx
@@ -1,0 +1,42 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export default function PipelineDetail() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const car = state?.car;
+
+  if (!car) {
+    return (
+      <div className="p-4">
+        <p>No vehicle data.</p>
+        <button
+          type="button"
+          className="mt-4 underline"
+          onClick={() => navigate('/pipeline')}
+        >
+          Back
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Stock {car['Stock Number']}</h1>
+      <ul className="list-disc pl-5">
+        {Object.entries(car).map(([key, value]) => (
+          <li key={key}>
+            <strong>{key}:</strong> {value}
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        className="mt-4 underline"
+        onClick={() => navigate('/pipeline')}
+      >
+        Back
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/pipeline` route with CSV inventory upload and list view
- add detail page for individual vehicles
- integrate pipeline page into navigation and document title

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c76c1d9c83269ca655ef4140622d