### PR TITLE
Add playground menu and enhance pipeline action items

### DIFF
--- a/src/pages/Pipeline.jsx
+++ b/src/pages/Pipeline.jsx
@@ -141,7 +141,9 @@ export default function Pipeline() {
     status: getBadgeAndAction(car),
   }));
 
-  const actionItems = carsWithStatus.filter(({ status }) => status.action);
+  const actionItems = carsWithStatus.filter(
+    ({ status }) => status.action && status.action !== 'In recon'
+  );
 
   const sortIcon = (key) => {
     if (sortConfig.key !== key) return '';
@@ -157,7 +159,10 @@ export default function Pipeline() {
           <ul className="list-disc list-inside text-sm text-gray-700">
             {actionItems.map(({ car, status }) => (
               <li key={car['Stock Number']}>
-                <span className="font-medium">{car['Stock Number']}</span>: {status.action}
+                <span className="font-medium">
+                  {car['Stock Number']} {car.Year} {car.Make} {car.Model}
+                </span>
+                : {status.action}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- Expand Pipeline action summary to include stock number, year, make, and model while excluding vehicles in recon
- Consolidate non-pipeline pages into a password-protected "Playground" menu

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e69aa97483269f86d76d642fc6ef